### PR TITLE
Refactored the CSV, XML and JSON export endpoints

### DIFF
--- a/src/main/java/usi/si/seart/gseapp/controller/GitRepoController.java
+++ b/src/main/java/usi/si/seart/gseapp/controller/GitRepoController.java
@@ -5,9 +5,6 @@ import usi.si.seart.gseapp.dto.GitRepoDtoList;
 import usi.si.seart.gseapp.dto.GitRepoDtoListPaginated;
 import usi.si.seart.gseapp.db_access_service.GitRepoService;
 import usi.si.seart.gseapp.util.FileSystemResourceCustom;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import com.opencsv.CSVWriter;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
@@ -22,11 +19,8 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.persistence.EntityNotFoundException;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
-import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.List;
 
 @RestController
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
@@ -34,15 +28,6 @@ import java.util.List;
 public class GitRepoController {
     static Logger logger = LoggerFactory.getLogger(GitRepoController.class);
     final static String downloadFolder = "download-temp/";
-    static ObjectMapper om;
-    static XmlMapper xmlm;
-    static {
-        SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
-        om = new ObjectMapper();
-        om.setDateFormat(df);
-        xmlm = new XmlMapper();
-        xmlm.setDateFormat(df);
-    }
 
     GitRepoService gitRepoService;
     GitRepoConverter gitRepoConverter;
@@ -99,43 +84,43 @@ public class GitRepoController {
     }
 
     @GetMapping(value = "/api/r/download/{fileformat}")
-    public ResponseEntity<?> downloadResult(@PathVariable("fileformat") String fileformat,
-                                  @RequestParam(required = false, defaultValue = "") String name,
-                                  @RequestParam(required = false, defaultValue = "false") Boolean nameEquals,
-                                  @RequestParam(required = false, defaultValue = "") String language,
-                                  @RequestParam(required = false, defaultValue = "") String license,
-                                  @RequestParam(required = false, defaultValue = "") String label,
-                                  @RequestParam(required = false) Long commitsMin,
-                                  @RequestParam(required = false) Long commitsMax,
-                                  @RequestParam(required = false) Long contributorsMin,
-                                  @RequestParam(required = false) Long contributorsMax,
-                                  @RequestParam(required = false) Long issuesMin,
-                                  @RequestParam(required = false) Long issuesMax,
-                                  @RequestParam(required = false) Long pullsMin,
-                                  @RequestParam(required = false) Long pullsMax,
-                                  @RequestParam(required = false) Long branchesMin,
-                                  @RequestParam(required = false) Long branchesMax,
-                                  @RequestParam(required = false) Long releasesMin,
-                                  @RequestParam(required = false) Long releasesMax,
-                                  @RequestParam(required = false) Long starsMin,
-                                  @RequestParam(required = false) Long starsMax,
-                                  @RequestParam(required = false) Long watchersMin,
-                                  @RequestParam(required = false) Long watchersMax,
-                                  @RequestParam(required = false) Long forksMin,
-                                  @RequestParam(required = false) Long forksMax,
-                                  @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") Date createdMin,
-                                  @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") Date createdMax,
-                                  @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") Date committedMin,
-                                  @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") Date committedMax,
-                                  @RequestParam(required = false, defaultValue = "false") Boolean excludeForks,
-                                  @RequestParam(required = false, defaultValue = "false") Boolean onlyForks,
-                                  @RequestParam(required = false, defaultValue = "false") Boolean hasIssues,
-                                  @RequestParam(required = false, defaultValue = "false") Boolean hasPulls,
-                                  @RequestParam(required = false, defaultValue = "false") Boolean hasWiki,
-                                  @RequestParam(required = false, defaultValue = "false") Boolean hasLicense)
-    {
-
-        if(!fileformat.equals("csv") && !fileformat.equals("json") && !fileformat.equals("xml"))
+    public ResponseEntity<?> downloadResult(
+            @PathVariable("fileformat") String fileformat,
+            @RequestParam(required = false, defaultValue = "") String name,
+            @RequestParam(required = false, defaultValue = "false") Boolean nameEquals,
+            @RequestParam(required = false, defaultValue = "") String language,
+            @RequestParam(required = false, defaultValue = "") String license,
+            @RequestParam(required = false, defaultValue = "") String label,
+            @RequestParam(required = false) Long commitsMin,
+            @RequestParam(required = false) Long commitsMax,
+            @RequestParam(required = false) Long contributorsMin,
+            @RequestParam(required = false) Long contributorsMax,
+            @RequestParam(required = false) Long issuesMin,
+            @RequestParam(required = false) Long issuesMax,
+            @RequestParam(required = false) Long pullsMin,
+            @RequestParam(required = false) Long pullsMax,
+            @RequestParam(required = false) Long branchesMin,
+            @RequestParam(required = false) Long branchesMax,
+            @RequestParam(required = false) Long releasesMin,
+            @RequestParam(required = false) Long releasesMax,
+            @RequestParam(required = false) Long starsMin,
+            @RequestParam(required = false) Long starsMax,
+            @RequestParam(required = false) Long watchersMin,
+            @RequestParam(required = false) Long watchersMax,
+            @RequestParam(required = false) Long forksMin,
+            @RequestParam(required = false) Long forksMax,
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") Date createdMin,
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") Date createdMax,
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") Date committedMin,
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") Date committedMax,
+            @RequestParam(required = false, defaultValue = "false") Boolean excludeForks,
+            @RequestParam(required = false, defaultValue = "false") Boolean onlyForks,
+            @RequestParam(required = false, defaultValue = "false") Boolean hasIssues,
+            @RequestParam(required = false, defaultValue = "false") Boolean hasPulls,
+            @RequestParam(required = false, defaultValue = "false") Boolean hasWiki,
+            @RequestParam(required = false, defaultValue = "false") Boolean hasLicense
+    ){
+        if(!fileformat.matches("csv|json|xml"))
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
 
         GitRepoDtoList repoDtos = gitRepoService.advancedSearch(name, nameEquals, language, license, label, commitsMin,
@@ -146,53 +131,33 @@ public class GitRepoController {
                 committedMin, committedMax, excludeForks, onlyForks,
                 hasIssues, hasPulls, hasWiki, hasLicense);
 
-        String tempFileName = System.currentTimeMillis()+".temp";
-        File tempFile = new File(downloadFolder +tempFileName);
+        String tempFileName = System.currentTimeMillis() + ".temp";
+        File tempFile = new File(downloadFolder + tempFileName);
         tempFile.getParentFile().mkdirs();
 
-        String mediaType = "", outputFileName="";
-        if(fileformat.equals("csv")) {
-            mediaType = "text/csv";
-            outputFileName = "results.csv";
-
-            // Write to file
-            try {
-                CSVWriter writer = new CSVWriter(new FileWriter(tempFile.getAbsolutePath()));
-                List<String[]> rows = gitRepoConverter.repoDtoListToCSVRowList(repoDtos);
-                writer.writeAll(rows);
-                writer.close();
-            } catch (IOException ex){
-                logger.error(ex.getMessage());
-                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        String mediaType = "text/";
+        try {
+            switch (fileformat){
+                case "csv":
+                    mediaType += fileformat;
+                    gitRepoConverter.repoListToCSV(tempFile, repoDtos);
+                    break;
+                case "json":
+                    mediaType += "plain";
+                    gitRepoConverter.repoListToJSON(tempFile, repoDtos);
+                    break;
+                case "xml":
+                    mediaType += fileformat;
+                    gitRepoConverter.repoListToXML(tempFile, repoDtos);
+                    break;
             }
-        }
-        else if(fileformat.equals("json")) {
-            mediaType = "text/plain";
-            outputFileName = "results.json";
-
-            // Write to file
-            try {
-                om.writeValue(tempFile, repoDtos);
-            } catch (IOException ex){
-                logger.error(ex.getMessage());
-                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-            }
-        }
-        else if(fileformat.equals("xml")) {
-            mediaType = "text/xml";
-            outputFileName = "results.xml";
-
-            // Write to file
-            try {
-                xmlm.writeValue(tempFile, repoDtos);
-            } catch (IOException ex){
-                logger.error(ex.getMessage());
-                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-            }
+        } catch (IOException ex) {
+            logger.error(ex.getMessage());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
 
         return ResponseEntity.ok()
-                .header("Content-Disposition", "attachment; filename="+outputFileName)
+                .header("Content-Disposition", "attachment; filename=results." + fileformat)
                 .contentLength(tempFile.length())
                 .contentType(MediaType.parseMediaType(mediaType))
                 .body(new FileSystemResourceCustom(tempFile));

--- a/src/main/java/usi/si/seart/gseapp/dto/GitRepoDto.java
+++ b/src/main/java/usi/si/seart/gseapp/dto/GitRepoDto.java
@@ -39,11 +39,11 @@ public class GitRepoDto {
     Boolean hasWiki;
     Boolean isArchived;
     @Builder.Default
-    @JacksonXmlElementWrapper(localName = "GitRepoLanguages")
-    @JacksonXmlProperty(localName = "GitRepoLanguage")
+    @JacksonXmlElementWrapper(localName = "languages")
+    @JacksonXmlProperty(localName = "language")
     List<GitRepoLanguageDto> languages = new ArrayList<>();
     @Builder.Default
-    @JacksonXmlElementWrapper(localName = "GitRepoLabels")
-    @JacksonXmlProperty(localName = "GitRepoLabel")
+    @JacksonXmlElementWrapper(localName = "labels")
+    @JacksonXmlProperty(localName = "label")
     List<GitRepoLabelDto> labels = new ArrayList<>();
 }

--- a/src/main/java/usi/si/seart/gseapp/dto/GitRepoDtoList.java
+++ b/src/main/java/usi/si/seart/gseapp/dto/GitRepoDtoList.java
@@ -13,10 +13,10 @@ import java.util.List;
 @Getter
 @Setter
 @Builder
-@JacksonXmlRootElement(localName = "GitRepoList")
+@JacksonXmlRootElement(localName = "repositories")
 public class GitRepoDtoList {
     @Builder.Default
-    @JacksonXmlElementWrapper(localName = "items")
-    @JacksonXmlProperty(localName = "GitRepo")
+    @JacksonXmlElementWrapper(useWrapping = false)
+    @JacksonXmlProperty(localName = "repository")
     List<GitRepoDto> items = new ArrayList<>();
 }

--- a/src/main/java/usi/si/seart/gseapp/dto/GitRepoLabelDto.java
+++ b/src/main/java/usi/si/seart/gseapp/dto/GitRepoLabelDto.java
@@ -1,5 +1,7 @@
 package usi.si.seart.gseapp.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -8,6 +10,8 @@ import lombok.Setter;
 @Setter
 @Builder
 public class GitRepoLabelDto {
+    @JsonIgnore
     Long id;
+    @JacksonXmlProperty(localName = "name")
     String label;
 }

--- a/src/main/java/usi/si/seart/gseapp/dto/GitRepoLanguageDto.java
+++ b/src/main/java/usi/si/seart/gseapp/dto/GitRepoLanguageDto.java
@@ -1,5 +1,8 @@
 package usi.si.seart.gseapp.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -7,8 +10,11 @@ import lombok.Setter;
 @Getter
 @Setter
 @Builder
+@JsonPropertyOrder({"language", "sizeOfCode"})
 public class GitRepoLanguageDto {
+    @JsonIgnore
     Long id;
+    @JacksonXmlProperty(localName = "name")
     String language;
     Long sizeOfCode;
 }


### PR DESCRIPTION
A variety of changes aimed at improving the quality of code for the `/api/r/download/{fileformat}` endpoint:

* All the code related to the conversion and file writing has been moved from the [GitRepoController](https://github.com/seart-group/ghs/blob/master/src/main/java/usi/si/seart/gseapp/controller/GitRepoController.java) and into [GitRepoConverter](https://github.com/seart-group/ghs/blob/master/src/main/java/usi/si/seart/gseapp/converter/GitRepoConverter.java).
* This separation of concerns allowed the `downloadResult` method to be greatly simplified.
* Simplified conversion from `GitRepoDTO` to CSV row. Converter now only places an empty string in case of 'no data'.
* Added annotations to the DTO classes which make tag/field naming in the exports clearer.