### PR TITLE
Removing deleted/private repositories from the database

### DIFF
--- a/src/main/java/usi/si/seart/gseapp/controller/AdminController.java
+++ b/src/main/java/usi/si/seart/gseapp/controller/AdminController.java
@@ -103,12 +103,12 @@ public class AdminController {
 
     @GetMapping("/api/s")
     public ResponseEntity<?> getSchedulingRate(){
-        return ResponseEntity.ok(applicationPropertyService.getScheduling());
+        return ResponseEntity.ok(applicationPropertyService.getCrawlScheduling());
     }
 
     @PutMapping("/api/s")
     public ResponseEntity<?> setSchedulingRate(@RequestBody Long rate){
-        applicationPropertyService.setScheduling(rate);
+        applicationPropertyService.setCrawlScheduling(rate);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/usi/si/seart/gseapp/db_access_service/ApplicationPropertyService.java
+++ b/src/main/java/usi/si/seart/gseapp/db_access_service/ApplicationPropertyService.java
@@ -5,8 +5,8 @@ import java.util.Date;
 public interface ApplicationPropertyService {
     Boolean getEnabled();
     void setEnabled(Boolean value);
-    Long getScheduling();
-    void setScheduling(Long value);
+    Long getCrawlScheduling();
+    void setCrawlScheduling(Long value);
     Date getStartDate();
     void setStartDate(Date value);
 }

--- a/src/main/java/usi/si/seart/gseapp/db_access_service/ApplicationPropertyServiceImpl.java
+++ b/src/main/java/usi/si/seart/gseapp/db_access_service/ApplicationPropertyServiceImpl.java
@@ -18,7 +18,10 @@ public class ApplicationPropertyServiceImpl implements ApplicationPropertyServic
     Boolean enabled;
 
     @Value(value = "${app.crawl.scheduling}")
-    Long scheduling;
+    Long crawlScheduling;
+
+    @Value(value = "${app.cleanup.scheduling}")
+    Long cleanUpScheduling;
 
     @Value("#{new java.text.SimpleDateFormat(\"yyyy-MM-dd'T'HH:mm:ss\").parse(\"${app.crawl.startdate}\")}")
     Date startDate;

--- a/src/main/java/usi/si/seart/gseapp/db_access_service/GitRepoService.java
+++ b/src/main/java/usi/si/seart/gseapp/db_access_service/GitRepoService.java
@@ -38,6 +38,7 @@ public interface GitRepoService {
     StringList getAllLabels();
     StringList getAllLanguages();
     StringList getAllLicenses();
+    StringList getAllRepoNames();
     StringLongDtoList getAllLanguageStatistics();
     StringLongDtoList getMainLanguageStatistics();
     void createUpdateLabels(GitRepo repo, List<GitRepoLabel> labels);

--- a/src/main/java/usi/si/seart/gseapp/db_access_service/GitRepoServiceImpl.java
+++ b/src/main/java/usi/si/seart/gseapp/db_access_service/GitRepoServiceImpl.java
@@ -282,6 +282,11 @@ public class GitRepoServiceImpl implements GitRepoService {
     }
 
     @Override
+    public StringList getAllRepoNames(){
+        return StringList.builder().items(gitRepoRepository.findAllRepoNames()).build();
+    }
+
+    @Override
     public StringLongDtoList getAllLanguageStatistics(){
         List<Object[]> languages = gitRepoLanguageRepository.getLanguageStatistics();
         StringLongDtoList stats = StringLongDtoList.builder().build();

--- a/src/main/java/usi/si/seart/gseapp/job/CleanUpProjectsJob.java
+++ b/src/main/java/usi/si/seart/gseapp/job/CleanUpProjectsJob.java
@@ -1,0 +1,149 @@
+package usi.si.seart.gseapp.job;
+
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
+import lombok.experimental.NonFinal;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import usi.si.seart.gseapp.model.GitRepo;
+import usi.si.seart.gseapp.repository.GitRepoRepository;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@EnableScheduling
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+public class CleanUpProjectsJob {
+
+    private static final int RUN_COMMAND_TIMEOUT = -3;
+    static Logger logger = LoggerFactory.getLogger(CleanUpProjectsJob.class);
+
+    @NonFinal boolean running = false;
+    GitRepoRepository gitRepoRepository;
+
+    @Autowired
+    public CleanUpProjectsJob(GitRepoRepository gitRepoRepository)
+    {
+        this.gitRepoRepository = gitRepoRepository;
+    }
+
+//  @EventListener(ApplicationReadyEvent.class) // instead of scheduling, this line runs the method once server is up
+    @Scheduled(fixedRateString = "#{@applicationPropertyServiceImpl.getCleanUpScheduling()}")
+    public void run(){
+        if (this.running) {
+            logger.error("CleanUpProjectsJob wanted to run while the prior job still running!!!!");
+            return;
+        }
+        this.running = true;
+        CleanUp();
+        this.running = false;
+
+    }
+
+    private void CleanUp() {
+        logger.info("CleanUpProjectsJob started ....");
+        List<String> allRepos = gitRepoRepository.findAllRepoNames();
+
+        final int TOTAL = allRepos.size();
+        logger.info("CleanUpProjectsJob started on {} repositories ...", TOTAL);
+
+        int cur=0, nDeleted=0;
+        for(String repo: allRepos)
+        {
+            cur++;
+            String repoURL = String.format("https://github.com/%s", repo);
+            logger.debug("{}/{}\tChecking if repo exists: {}",cur, TOTAL, repoURL);
+            boolean exists = CheckIfRepoExists(repoURL);
+            if(exists==false) {
+                logger.info("{}/{}\tChecking if repo exists: {} ==> TO BE DELETED", cur, TOTAL, repoURL);
+                Optional<GitRepo> opt = gitRepoRepository.findGitRepoByName(repo.toLowerCase());
+                if (opt.isPresent()) {
+                    GitRepo existing = opt.get();
+                    gitRepoRepository.delete(existing);
+                    nDeleted++;
+                }
+            }
+        }
+        logger.info("CleanUpProjectsJob finished on {} repositories. {} DELETED.", TOTAL, nDeleted);
+    }
+
+
+
+    /**
+     * Check if a repo at given url is publicly available.
+     * @param repo_http_url The http url of the repo. Technically the same code should also work for ssh url, but in my
+     *                      tests, ssh prompts (for adding fingerprint, whatsoever) which kills the command as we disabled
+     *                      prompts. (Prompts should remain disabled, otherwise GitHub asks user/pass for private repos)
+     */
+    private boolean CheckIfRepoExists(String repo_http_url)
+    {
+        boolean res;
+        try {
+//        int res = RunCommand(, 60, env);
+            String[] cmd_array = List.of("git", "ls-remote", repo_http_url).toArray(new String[0]);
+            ProcessBuilder pb = new ProcessBuilder(cmd_array);
+            pb.environment().put("GIT_TERMINAL_PROMPT", "0");
+            Process process = pb.start();
+
+            InputStreamConsumerThread inputConsumer = new InputStreamConsumerThread(process.getInputStream());
+            InputStreamConsumerThread errorConsumer = new InputStreamConsumerThread(process.getErrorStream());
+            inputConsumer.start();
+            errorConsumer.start();
+
+            boolean noTimeout = process.waitFor(60, TimeUnit.SECONDS);
+            int returnCode = 0;
+            if(noTimeout)
+                returnCode = process.exitValue();
+            else {
+                while(process.isAlive()) {
+                    System.err.println("Trying to kill timed-out process "+process.pid()+" ...");
+                    process.destroyForcibly();
+                }
+                returnCode =  RUN_COMMAND_TIMEOUT;
+            }
+
+            // Why also RUN_COMMAND_TIMEOUT? Because it's safer to keep projects which we fail to check, than removing them
+            // from db. Let's say there is a bug with our implementation, do we prefer to lose repos one by one? nope.
+            // Once the code is reviewed, we can drop the "res == RUN_COMMAND_TIMEOUT" part.
+            res = (returnCode == 0 || returnCode == RUN_COMMAND_TIMEOUT);
+        } catch (Exception e) {
+            System.err.println("Exception: "+e);
+            e.printStackTrace();
+            res = true; // We return "true" to prevent deleting repos from GHS database in case of errors
+        }
+
+        return res;
+    }
+
+    public static class InputStreamConsumerThread extends Thread
+    {
+        private final InputStream is;
+
+        public InputStreamConsumerThread (InputStream is)
+        {
+            this.is=is;
+        }
+
+        public void run()
+        {
+            try(BufferedReader br = new BufferedReader(new InputStreamReader(is)))
+            {
+                for (String line = br.readLine(); line != null; line = br.readLine());
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/main/java/usi/si/seart/gseapp/job/JobScheduler.java
+++ b/src/main/java/usi/si/seart/gseapp/job/JobScheduler.java
@@ -31,7 +31,7 @@ public class JobScheduler {
         this.applicationPropertyService = applicationPropertyService;
     }
 
-    @Scheduled(fixedRateString = "#{@applicationPropertyServiceImpl.getScheduling()}")
+    @Scheduled(fixedRateString = "#{@applicationPropertyServiceImpl.getCrawlScheduling()}")
     public void run(){
         try {
             if(crawlProjectsJob.running) {
@@ -40,7 +40,7 @@ public class JobScheduler {
                 return;
             }
             crawlProjectsJob.run();
-            logger.info("Next crawl scheduled for: " + Date.from(Instant.now().plusMillis(applicationPropertyService.getScheduling())));
+            logger.info("Next crawl scheduled for: " + Date.from(Instant.now().plusMillis(applicationPropertyService.getCrawlScheduling())));
         } catch (Exception ex) {
             crawlProjectsJob.running = false;
             ex.printStackTrace();

--- a/src/main/java/usi/si/seart/gseapp/repository/GitRepoRepository.java
+++ b/src/main/java/usi/si/seart/gseapp/repository/GitRepoRepository.java
@@ -13,4 +13,6 @@ public interface GitRepoRepository extends JpaRepository<GitRepo,Long> {
     List<Object[]> getLanguageStatistics();
     @Query("select distinct r.license from GitRepo r where r.license is not null group by r.license order by count(r.license) desc")
     List<String> findAllLicenses();
+    @Query("SELECT r.name FROM GitRepo r ORDER BY r.crawled ASC")
+    List<String> findAllRepoNames();
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,6 +25,8 @@ spring.flyway.password=Lugano2020
 logging.level.org.flywaydb=debug
 
 app.crawl.enabled=true
-# app.crawl.scheduling: in milliSecond # every 6 hours (note: we mined up to 2h ago)
+# app.crawl.scheduling: in milliSecond # every 6 hours (note: we mined up to 2h ago) = 1000*60*60*6 = 21600000
 app.crawl.scheduling=21600000
 app.crawl.startdate=2008-01-01T00:00:00
+# app.cleanup.scheduling: in milliSecond # Once a week = every 7*24 hours = 1000*60*60*24*7 = 604800000
+app.cleanup.scheduling=604800000


### PR DESCRIPTION
This commit adds a new scheduler which kicks off once a week (see `application.properties`) and checks all the existing repositories in the database if they are publicly accessible (using `git ls-remote` command).