### PR TITLE
Introduce summary table for `git_repo_metric`

### DIFF
--- a/flyway/sql/V11__summary.sql
+++ b/flyway/sql/V11__summary.sql
@@ -1,0 +1,191 @@
+CREATE TABLE git_repo_metric_aggregate (
+    `repo_id` BIGINT NOT NULL
+        PRIMARY KEY,
+    `lines_blank` BIGINT NOT NULL,
+    `lines_code` BIGINT NOT NULL,
+    `lines_comment` BIGINT NOT NULL,
+    `lines` BIGINT NOT NULL,
+    `lines_non_blank` BIGINT NOT NULL
+) SELECT * FROM git_repo_metrics_by_id;
+
+ALTER TABLE git_repo_metric_aggregate
+ADD CONSTRAINT FOREIGN KEY (`repo_id`) REFERENCES git_repo(`id`);
+
+CREATE INDEX git_repo_metric_aggregate_idx ON git_repo_metric_aggregate(`lines_non_blank`, `lines_code`, `lines_comment`);
+
+RENAME TABLE git_repo_metrics TO git_repo_metric;
+
+CREATE TRIGGER git_repo_metric_insert
+AFTER INSERT ON git_repo_metric
+FOR EACH ROW
+BEGIN
+    DECLARE `_repo_id` BIGINT;
+
+    DECLARE `lines_blank_delta` INTEGER;
+    DECLARE `lines_code_delta` INTEGER;
+    DECLARE `lines_comment_delta` INTEGER;
+    DECLARE `lines_delta` INTEGER;
+    DECLARE `lines_non_blank_delta` INTEGER;
+
+    DECLARE initialized BIT;
+
+    SET `_repo_id` = NEW.`repo_id`;
+
+    SET `lines_blank_delta` = NEW.`lines_blank`;
+    SET `lines_code_delta` = NEW.`lines_code`;
+    SET `lines_comment_delta` = NEW.`lines_comment`;
+    SET `lines_delta` = NEW.`lines`;
+    SET `lines_non_blank_delta` = NEW.`lines_non_blank`;
+
+    SELECT EXISTS(
+        SELECT `repo_id`
+        FROM git_repo_metric_aggregate
+        WHERE `repo_id` = `_repo_id`
+    ) INTO initialized;
+
+    IF initialized THEN
+        UPDATE git_repo_metric_aggregate
+        SET
+            `lines_blank` = `lines_blank` + `lines_blank_delta`,
+            `lines_code` = `lines_code` + `lines_code_delta`,
+            `lines_comment` = `lines_comment` + `lines_comment_delta`,
+            `lines` = `lines` + `lines_delta`,
+            `lines_non_blank` = `lines_non_blank` + `lines_non_blank_delta`
+        WHERE `repo_id` = `_repo_id`;
+    ELSE
+        INSERT INTO git_repo_metric_aggregate VALUE (
+            `_repo_id`,
+            `lines_blank_delta`,
+            `lines_code_delta`,
+            `lines_comment_delta`,
+            `lines_delta`,
+            `lines_non_blank_delta`
+        );
+    END IF;
+END;
+
+CREATE TRIGGER git_repo_metric_delete
+AFTER DELETE ON git_repo_metric
+FOR EACH ROW
+BEGIN
+    DECLARE `_repo_id` BIGINT;
+
+    DECLARE `lines_blank_delta` INTEGER;
+    DECLARE `lines_code_delta` INTEGER;
+    DECLARE `lines_comment_delta` INTEGER;
+    DECLARE `lines_delta` INTEGER;
+    DECLARE `lines_non_blank_delta` INTEGER;
+
+    DECLARE `lines_blank_current` INTEGER;
+    DECLARE `lines_code_current` INTEGER;
+    DECLARE `lines_comment_current` INTEGER;
+    DECLARE `lines_current` INTEGER;
+    DECLARE `lines_non_blank_current` INTEGER;
+
+    SET  `_repo_id` = OLD.`repo_id`;
+
+    SET `lines_blank_delta` = -OLD.`lines_blank`;
+    SET `lines_code_delta` = -OLD.`lines_code`;
+    SET `lines_comment_delta` = -OLD.`lines_comment`;
+    SET `lines_delta` = -OLD.`lines`;
+    SET `lines_non_blank_delta` = -OLD.`lines_non_blank`;
+
+    SELECT
+        `lines_blank` + `lines_blank_delta` AS lines_blank_current,
+        `lines_code` + `lines_code_delta` AS lines_code_current,
+        `lines_comment` + `lines_comment_delta` AS lines_comment_current,
+        `lines` + `lines_delta` AS lines_current,
+        `lines_non_blank` + `lines_non_blank_delta` AS lines_non_blank_current
+    INTO
+        `lines_blank_current`,
+        `lines_code_current`,
+        `lines_comment_current`,
+        `lines_current`,
+        `lines_non_blank_current`
+    FROM git_repo_metric_aggregate
+    WHERE `repo_id` = `_repo_id`;
+
+    IF (
+        `lines_blank_current` = 0 AND
+        `lines_code_current` = 0 AND
+        `lines_comment_current` = 0 AND
+        `lines_current` = 0 AND
+        `lines_non_blank_current` = 0
+    ) THEN
+        DELETE FROM git_repo_metric_aggregate
+        WHERE `repo_id` = `_repo_id`;
+    ELSE
+        UPDATE git_repo_metric_aggregate
+        SET
+            `lines_blank` = `lines_blank_current`,
+            `lines_code` = `lines_code_current`,
+            `lines_comment` = `lines_comment_current`,
+            `lines` = `lines_current`,
+            `lines_non_blank` = `lines_non_blank_current`
+        WHERE `repo_id` = `_repo_id`;
+    END IF;
+END;
+
+CREATE TRIGGER git_repo_metric_update
+AFTER UPDATE ON git_repo_metric
+FOR EACH ROW
+BEGIN
+    DECLARE `_repo_id` BIGINT;
+
+    DECLARE `lines_blank_delta` INTEGER;
+    DECLARE `lines_code_delta` INTEGER;
+    DECLARE `lines_comment_delta` INTEGER;
+    DECLARE `lines_delta` INTEGER;
+    DECLARE `lines_non_blank_delta` INTEGER;
+
+    DECLARE `lines_blank_current` INTEGER;
+    DECLARE `lines_code_current` INTEGER;
+    DECLARE `lines_comment_current` INTEGER;
+    DECLARE `lines_current` INTEGER;
+    DECLARE `lines_non_blank_current` INTEGER;
+
+    SET  `_repo_id` = NEW.`repo_id`;
+
+    SET `lines_blank_delta` = NEW.`lines_blank` - OLD.`lines_blank`;
+    SET `lines_code_delta` = NEW.`lines_code` - OLD.`lines_code`;
+    SET `lines_comment_delta` = NEW.`lines_comment` - OLD.`lines_comment`;
+    SET `lines_delta` = NEW.`lines` - OLD.`lines`;
+    SET `lines_non_blank_delta` = NEW.`lines_non_blank` - OLD.`lines_non_blank`;
+
+    SELECT
+        `lines_blank` + `lines_blank_delta` AS `lines_blank_current`,
+        `lines_code` + `lines_code_delta` AS `lines_code_current`,
+        `lines_comment` + `lines_comment_delta` AS `lines_comment_current`,
+        `lines` + `lines_delta` AS `lines_current`,
+        `lines_non_blank` + `lines_non_blank_delta` AS `lines_non_blank_current`
+    INTO
+        `lines_blank_current`,
+        `lines_code_current`,
+        `lines_comment_current`,
+        `lines_current`,
+        `lines_non_blank_current`
+    FROM git_repo_metric_aggregate
+    WHERE `repo_id` = `_repo_id`;
+
+    IF (
+        `lines_blank_current` = 0 AND
+        `lines_code_current` = 0 AND
+        `lines_comment_current` = 0 AND
+        `lines_current` = 0 AND
+        `lines_non_blank_current` = 0
+    ) THEN
+        DELETE FROM git_repo_metric_aggregate
+        WHERE `repo_id` = `_repo_id`;
+    ELSE
+        UPDATE git_repo_metric_aggregate
+        SET
+            `lines_blank` = `lines_blank_current`,
+            `lines_code` = `lines_code_current`,
+            `lines_comment` = `lines_comment_current`,
+            `lines` = `lines_current`,
+            `lines_non_blank` = `lines_non_blank_current`
+        WHERE `repo_id` = `_repo_id`;
+    END IF;
+END;
+
+DROP VIEW git_repo_metrics_by_id;

--- a/html/css/main.css
+++ b/html/css/main.css
@@ -209,9 +209,17 @@ input::-webkit-calendar-picker-indicator {
     height: 3rem!important;
 }
 
+.tooltip.show {
+    opacity: 1!important;
+}
+
 .tooltip-inner {
     border-radius: 0!important;
-    max-width: 400px!important;
+    max-width: 350px!important;
+}
+
+.tooltip[data-popper-placement='right'] > .tooltip-inner {
+    text-align: left!important;
 }
 
 .modal-content {

--- a/html/index.html
+++ b/html/index.html
@@ -497,11 +497,15 @@
               <div class="col">
                 <h5 class="my-3">
                   Size of codebase
-                  <i class="bi bi-info-circle" data-bs-toggle="tooltip"
-                     data-bs-title="These are filters related to the codebase. If the target programming language is specified, the filters will only apply to that language. If no language is specified the filters will apply to the combined metrics of all languages in the repositories."
-                     data-bs-placement="right"></i>
+                  <i data-bs-toggle="tooltip"
+                     data-bs-title="
+                     These filters are codebase-specific and are language-restricted.
+                     When specifying the target programming language, they apply exclusively to that language,
+                     otherwise affecting cumulative metrics across all languages in the repository."
+                     data-bs-placement="right"
+                     class="bi bi-info-circle"
+                  ></i>
                 </h5>
-
               </div>
             </div>
             <div class="row">

--- a/src/main/java/ch/usi/si/seart/converter/GitRepoToDtoConverter.java
+++ b/src/main/java/ch/usi/si/seart/converter/GitRepoToDtoConverter.java
@@ -2,9 +2,9 @@ package ch.usi.si.seart.converter;
 
 import ch.usi.si.seart.dto.GitRepoDto;
 import ch.usi.si.seart.model.GitRepo;
-import ch.usi.si.seart.model.GitRepoMetricAggregate;
 import ch.usi.si.seart.model.Label;
 import ch.usi.si.seart.model.Topic;
+import ch.usi.si.seart.model.join.GitRepoMetricAggregate;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.lang.NonNull;
 

--- a/src/main/java/ch/usi/si/seart/converter/SearchParameterDtoToSpecificationConverter.java
+++ b/src/main/java/ch/usi/si/seart/converter/SearchParameterDtoToSpecificationConverter.java
@@ -2,13 +2,13 @@ package ch.usi.si.seart.converter;
 
 import ch.usi.si.seart.dto.SearchParameterDto;
 import ch.usi.si.seart.model.GitRepo;
-import ch.usi.si.seart.model.GitRepoMetricAggregate;
-import ch.usi.si.seart.model.GitRepoMetricAggregate_;
 import ch.usi.si.seart.model.GitRepo_;
 import ch.usi.si.seart.model.Label_;
 import ch.usi.si.seart.model.Language_;
 import ch.usi.si.seart.model.Topic_;
 import ch.usi.si.seart.model.join.GitRepoMetric;
+import ch.usi.si.seart.model.join.GitRepoMetricAggregate;
+import ch.usi.si.seart.model.join.GitRepoMetricAggregate_;
 import ch.usi.si.seart.model.join.GitRepoMetric_;
 import ch.usi.si.seart.repository.criteria.AlwaysTrueCriteria;
 import ch.usi.si.seart.repository.criteria.Criteria;

--- a/src/main/java/ch/usi/si/seart/model/GitRepo.java
+++ b/src/main/java/ch/usi/si/seart/model/GitRepo.java
@@ -2,6 +2,7 @@ package ch.usi.si.seart.model;
 
 import ch.usi.si.seart.model.join.GitRepoLanguage;
 import ch.usi.si.seart.model.join.GitRepoMetric;
+import ch.usi.si.seart.model.join.GitRepoMetricAggregate;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/ch/usi/si/seart/model/GitRepoMetricAggregate.java
+++ b/src/main/java/ch/usi/si/seart/model/GitRepoMetricAggregate.java
@@ -18,7 +18,7 @@ import javax.persistence.Table;
 @AllArgsConstructor
 @Entity
 @Immutable
-@Table(name = "git_repo_metrics_by_id")
+@Table(name = "git_repo_metric_aggregate")
 public class GitRepoMetricAggregate {
 
     @Id

--- a/src/main/java/ch/usi/si/seart/model/join/GitRepoMetric.java
+++ b/src/main/java/ch/usi/si/seart/model/join/GitRepoMetric.java
@@ -36,7 +36,7 @@ import java.util.Objects;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "git_repo_metrics")
+@Table(name = "git_repo_metric")
 @Entity
 public class GitRepoMetric {
 

--- a/src/main/java/ch/usi/si/seart/model/join/GitRepoMetricAggregate.java
+++ b/src/main/java/ch/usi/si/seart/model/join/GitRepoMetricAggregate.java
@@ -1,5 +1,6 @@
-package ch.usi.si.seart.model;
+package ch.usi.si.seart.model.join;
 
+import ch.usi.si.seart.model.GitRepo;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;


### PR DESCRIPTION
Rather than aggregating the code metrics in a view, we pre-compute them in a separate table called `git_repo_metric_aggregate`, which is kept in sync with `git_repo_metric` through triggers. The usage of a summary table allows us to also define indexes on it, which will no doubt make querying more efficient.