### PR TITLE
Docker setup improvements

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,51 @@
+name: 'Publish image builds to Docker Hub'
+on:
+  push:
+    branches: [ 'master' ]
+    tags: [ 'v*' ]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - dockerfile: docker/backup/Dockerfile
+            image: ghs/backup
+          - dockerfile: docker/database/Dockerfile
+            image: ghs/database
+          - dockerfile: docker/server/Dockerfile
+            image: ghs/server
+          - dockerfile: docker/website/Dockerfile
+            image: ghs/website
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: seart
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - id: meta
+        name: Extract metadata for Docker
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const patch = context.ref.substring(11)
+            const parts = patch.split('.')
+            const minor = `${parts[0]}.${parts[1]}`
+            const major = parts[0]
+            core.setOutput('tag-patch', patch)
+            core.setOutput('tag-minor', minor)
+            core.setOutput('tag-major', major)
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          file: ${{ matrix.dockerfile }}
+          tags: |
+            ${{ matrix.image }}:latest
+            ${{ matrix.image }}:${{ steps.meta.outputs.tag-major }}
+            ${{ matrix.image }}:${{ steps.meta.outputs.tag-minor }}
+            ${{ matrix.image }}:${{ steps.meta.outputs.tag-patch }}

--- a/README.md
+++ b/README.md
@@ -130,13 +130,14 @@ Regardless of which method you choose for hosting, the back-end CORS restricts y
 
 The deployment stack consists of the following containers:
 
-| Service/Container name |                                Image                                 | Purpose                           |      Enabled by Default       |
-|------------------------|:--------------------------------------------------------------------:|-----------------------------------|:-----------------------------:|
-| `gse-database`         |           [mysql](https://registry.hub.docker.com/_/mysql)           | for the database                  |      :white_check_mark:       |
-| `gse-migration`        |      [flyway](https://registry.hub.docker.com/r/flyway/flyway)       | for the schema migrations         |      :white_check_mark:       |
-| `gse-backup`           | [tiredofit/db-backup](https://hub.docker.com/r/tiredofit/db-backup/) | for the automatic backups         | :negative_squared_cross_mark: |
-| `gse-server`           |               [gse/backend](docker/server/Dockerfile)                | for the spring application itself |      :white_check_mark:       |
-| `gse-website`          |              [gse/frontend](docker/website/Dockerfile)               | for supplying the front-end files |      :white_check_mark:       |
+| Service/Container name |                                  Image                                  | Description                              |      Enabled by Default       |
+|------------------------|:-----------------------------------------------------------------------:|------------------------------------------|:-----------------------------:|
+| `gse-database`         |            [mysql](https://registry.hub.docker.com/_/mysql)             | Platform database                        |      :white_check_mark:       |
+| `gse-migration`        |        [flyway](https://registry.hub.docker.com/r/flyway/flyway)        | Database schema migration executions     |      :white_check_mark:       |
+| `gse-backup`           |  [tiredofit/db-backup](https://hub.docker.com/r/tiredofit/db-backup/)   | Automated database backups               | :negative_squared_cross_mark: |
+| `gse-server`           |                 [gse/backend](docker/server/Dockerfile)                 | Spring Boot server application           |      :white_check_mark:       |
+| `gse-website`          |                [gse/frontend](docker/website/Dockerfile)                | NGINX web server acting as HTML supplier |      :white_check_mark:       |
+| `gse-watchtower`       | [containrrr/watchtower](https://hub.docker.com/r/containrrr/watchtower) | Automatic Docker image updates           | :negative_squared_cross_mark: |
 
 The service dependency chain can be represented as follows:
 
@@ -146,6 +147,7 @@ graph RL
     gse-backup --> |service_completed_successfully| gse-migration
     gse-server --> |service_completed_successfully| gse-migration
     gse-website --> |service_healthy| gse-server
+    gse-watchtower --> |service_started| gse-website
 ```
 
 Deploying is as simple as, in the [docker-compose](docker-compose) directory, run:

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -75,37 +75,6 @@ services:
     networks:
       - default
 
-  gse-website:
-    build:
-      context: ../
-      dockerfile: docker/website/Dockerfile
-    image: gse/frontend:latest
-    container_name: gse-website
-    volumes:
-      - ./nginx/default.dev.conf:/etc/nginx/conf.d/default.conf
-    ports: [ "7030:80" ]
-    deploy:
-      restart_policy:
-        condition: on-failure
-        max_attempts: 5
-    depends_on:
-      gse-server:
-        condition: service_healthy
-    networks:
-      - default
-
-  gse-watchtower:
-    image: tianon/true:latest
-    container_name: gse-watchtower
-    restart: "no"
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    depends_on:
-      gse-website:
-        condition: service_started
-    networks:
-      - default
-
   gse-server:
     build:
       context: ../
@@ -137,6 +106,37 @@ services:
     depends_on:
       gse-migration:
         condition: service_completed_successfully
+    networks:
+      - default
+
+  gse-website:
+    build:
+      context: ../
+      dockerfile: docker/website/Dockerfile
+    image: gse/frontend:latest
+    container_name: gse-website
+    volumes:
+      - ./nginx/default.dev.conf:/etc/nginx/conf.d/default.conf
+    ports: [ "7030:80" ]
+    deploy:
+      restart_policy:
+        condition: on-failure
+        max_attempts: 5
+    depends_on:
+      gse-server:
+        condition: service_healthy
+    networks:
+      - default
+
+  gse-watchtower:
+    image: tianon/true:latest
+    container_name: gse-watchtower
+    restart: "no"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      gse-website:
+        condition: service_started
     networks:
       - default
 

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -94,6 +94,17 @@ services:
     networks:
       - default
 
+  gse-watchtower:
+    image: tianon/true:latest
+    container_name: gse-watchtower
+    restart: "no"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      gse-website:
+        condition: service_started
+    networks:
+      - default
 
   gse-server:
     build:


### PR DESCRIPTION
On each tag, Docker images will be built and pushed to our [Docker Hub account](https://hub.docker.com/u/seart). At the same time, our production deployment is configured to redeploy services with updated images using [watchtower](https://containrrr.dev/watchtower).

Fixes #236 