### PR TITLE
Refactor reactive web client configuration

### DIFF
--- a/src/main/java/ch/usi/si/seart/config/GraphQlConfig.java
+++ b/src/main/java/ch/usi/si/seart/config/GraphQlConfig.java
@@ -14,6 +14,7 @@ import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.ExchangeFunction;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
 
 @Configuration
 public class GraphQlConfig {
@@ -30,6 +31,11 @@ public class GraphQlConfig {
                 .defaultHeader("X-GitHub-Api-Version", properties.getApiVersion())
                 .filter(exchangeFilterFunction)
                 .build();
+    }
+
+    @Bean
+    HttpClient httpClient() {
+        return HttpClient.create();
     }
 
     @Bean

--- a/src/main/java/ch/usi/si/seart/config/GraphQlConfig.java
+++ b/src/main/java/ch/usi/si/seart/config/GraphQlConfig.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.graphql.client.GraphQlClient;
 import org.springframework.graphql.client.HttpGraphQlClient;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.ClientRequest;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
@@ -34,6 +35,11 @@ public class GraphQlConfig {
                 .defaultHeader("X-GitHub-Api-Version", properties.getApiVersion())
                 .filter(exchangeFilterFunction)
                 .build();
+    }
+
+    @Bean
+    ReactorClientHttpConnector reactorClientHttpConnector(HttpClient httpClient) {
+        return new ReactorClientHttpConnector(httpClient);
     }
 
     @Bean

--- a/src/main/java/ch/usi/si/seart/config/GraphQlConfig.java
+++ b/src/main/java/ch/usi/si/seart/config/GraphQlConfig.java
@@ -3,6 +3,7 @@ package ch.usi.si.seart.config;
 import ch.usi.si.seart.config.properties.GitHubProperties;
 import ch.usi.si.seart.github.Endpoint;
 import ch.usi.si.seart.github.GitHubTokenManager;
+import io.netty.channel.ChannelOption;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,6 +16,8 @@ import org.springframework.web.reactive.function.client.ExchangeFunction;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
 
 @Configuration
 public class GraphQlConfig {
@@ -35,7 +38,11 @@ public class GraphQlConfig {
 
     @Bean
     HttpClient httpClient() {
-        return HttpClient.create();
+        return HttpClient.create()
+                .disableRetry(true)
+                .responseTimeout(Duration.ofMinutes(1))
+                .option(ChannelOption.SO_KEEPALIVE, true)
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 60_000);
     }
 
     @Bean

--- a/src/main/java/ch/usi/si/seart/config/GraphQlConfig.java
+++ b/src/main/java/ch/usi/si/seart/config/GraphQlConfig.java
@@ -29,9 +29,14 @@ public class GraphQlConfig {
     }
 
     @Bean
-    WebClient webClient(ExchangeFilterFunction exchangeFilterFunction, GitHubProperties properties) {
+    WebClient webClient(
+            ExchangeFilterFunction exchangeFilterFunction,
+            ReactorClientHttpConnector reactorClientHttpConnector,
+            GitHubProperties properties
+    ) {
         return WebClient.builder()
                 .baseUrl(Endpoint.GRAPH_QL.toString())
+                .clientConnector(reactorClientHttpConnector)
                 .defaultHeader("X-GitHub-Api-Version", properties.getApiVersion())
                 .filter(exchangeFilterFunction)
                 .build();

--- a/src/main/java/ch/usi/si/seart/config/HttpClientConfig.java
+++ b/src/main/java/ch/usi/si/seart/config/HttpClientConfig.java
@@ -26,7 +26,7 @@ public class HttpClientConfig {
     }
 
     @Bean
-    LoggingInterceptor httpLoggingInterceptor() {
+    LoggingInterceptor loggingInterceptor() {
         Logger logger = LoggerFactory.getLogger(GitHubRestConnector.class);
         return new LoggingInterceptor(logger);
     }

--- a/src/main/java/ch/usi/si/seart/config/HttpClientConfig.java
+++ b/src/main/java/ch/usi/si/seart/config/HttpClientConfig.java
@@ -37,7 +37,7 @@ public class HttpClientConfig {
     }
 
     @Bean
-    public OkHttpClient httpClient(
+    public OkHttpClient okHttpClient(
             HeaderAttachmentInterceptor headerAttachmentInterceptor, LoggingInterceptor loggingInterceptor
     ) {
         return new OkHttpClient.Builder()

--- a/src/main/java/ch/usi/si/seart/github/GitHubTokenManager.java
+++ b/src/main/java/ch/usi/si/seart/github/GitHubTokenManager.java
@@ -38,7 +38,7 @@ import java.util.concurrent.TimeUnit;
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class GitHubTokenManager {
 
-    OkHttpClient client;
+    OkHttpClient httpClient;
 
     RetryTemplate retryTemplate;
 
@@ -52,13 +52,13 @@ public class GitHubTokenManager {
 
     @Autowired
     public GitHubTokenManager(
-            OkHttpClient client,
+            OkHttpClient httpClient,
             @Qualifier("timeLimitedRetryTemplate")
             RetryTemplate retryTemplate,
             ConversionService conversionService,
             GitHubProperties properties
     ) {
-        this.client = client;
+        this.httpClient = httpClient;
         this.retryTemplate = retryTemplate;
         this.conversionService = conversionService;
         this.tokens = new Cycle<>(properties.getTokens());
@@ -128,7 +128,7 @@ public class GitHubTokenManager {
             if (currentToken != null)
                 builder.header(HttpHeaders.AUTHORIZATION, "Bearer " + currentToken);
             Request request = builder.build();
-            Response response = client.newCall(request).execute();
+            Response response = httpClient.newCall(request).execute();
             int code = response.code();
             HttpStatus status = HttpStatus.valueOf(code);
             String phrase = status.getReasonPhrase();

--- a/src/main/java/ch/usi/si/seart/http/interceptor/LoggingInterceptor.java
+++ b/src/main/java/ch/usi/si/seart/http/interceptor/LoggingInterceptor.java
@@ -28,7 +28,8 @@ public class LoggingInterceptor implements Interceptor {
         try {
             response = chain.proceed(request);
         } catch (Exception ex) {
-            log.debug("<<< HTTP FAILURE", ex);
+            if (log.isDebugEnabled())
+                log.error("<<< HTTP FAILURE", ex);
             throw ex;
         }
         long endNs = System.nanoTime();

--- a/src/main/java/ch/usi/si/seart/reactive/LoggingFilterFunction.java
+++ b/src/main/java/ch/usi/si/seart/reactive/LoggingFilterFunction.java
@@ -1,0 +1,26 @@
+package ch.usi.si.seart.reactive;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import reactor.core.publisher.Mono;
+
+@AllArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+public class LoggingFilterFunction implements ExchangeFilterFunction {
+
+    Logger log;
+
+    @NotNull
+    @Override
+    public Mono<ClientResponse> filter(@NotNull ClientRequest request, @NotNull ExchangeFunction next) {
+        log.debug(">>> {} {}", request.method(), request.url());
+        return next.exchange(request);
+    }
+}


### PR DESCRIPTION
Introduces some overrides to default settings:

- read and connect timeout extended to 60 seconds
- sockets are kept alive and re-used for requests
- built-in retries are disabled

Also introduces new logging functionalities to the reactive clients