### PR TITLE
Improve heath checks for Spring and NGINX containers

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -128,6 +128,12 @@ services:
       restart_policy:
         condition: on-failure
         max_attempts: 5
+    healthcheck:
+        test: wget -q -O /dev/null http://localhost:80/nginx || exit 1
+        start_period: 15s
+        interval: 5s
+        timeout: 1s
+        retries: 5
     depends_on:
       gse-server:
         condition: service_healthy

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -102,9 +102,9 @@ services:
         condition: on-failure
         max_attempts: 5
     healthcheck:
-      test: curl --fail --silent localhost:8080/api || exit 1
       start_period: 20s
       interval: 10s
+      test: curl --silent --fail --request GET http://localhost:8080/api/actuator/health | jq --exit-status -n 'inputs | if has("status") then .status=="UP" else false end' > /dev/null || exit 1
       timeout: 5s
       retries: 5
     depends_on:

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -102,9 +102,9 @@ services:
         condition: on-failure
         max_attempts: 5
     healthcheck:
-      start_period: 20s
-      interval: 10s
       test: curl --silent --fail --request GET http://localhost:8080/api/actuator/health | jq --exit-status -n 'inputs | if has("status") then .status=="UP" else false end' > /dev/null || exit 1
+      start_period: 30s
+      interval: 15s
       timeout: 5s
       retries: 5
     depends_on:

--- a/docker-compose/nginx/default.dev.conf
+++ b/docker-compose/nginx/default.dev.conf
@@ -9,4 +9,11 @@ server {
     sub_filter_types application/javascript;
     sub_filter "http://localhost:8080" "http://localhost:48001";
   }
+
+  location /nginx {
+    stub_status on;
+    access_log off;
+    allow 127.0.0.1;
+    deny all;
+  }
 }

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -16,6 +16,7 @@ RUN apk update --quiet && \
             --quiet \
             git~=2.40.1 \
             cloc~=1.96 \
-            curl~=8.5.0
+            curl~=8.5.0 \
+            jq~=1.6
 
 ENTRYPOINT ["java", "-jar", "server.jar"]

--- a/src/main/java/ch/usi/si/seart/config/SecurityConfig.java
+++ b/src/main/java/ch/usi/si/seart/config/SecurityConfig.java
@@ -18,6 +18,8 @@ public class SecurityConfig {
         return httpSecurity
                 .csrf().csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
                 .and()
+                .authorizeRequests().antMatchers("/actuator/health").permitAll()
+                .and()
                 .authorizeRequests().antMatchers("/actuator/**").authenticated().anyRequest().permitAll()
                 .and()
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/src/main/java/ch/usi/si/seart/config/SecurityConfig.java
+++ b/src/main/java/ch/usi/si/seart/config/SecurityConfig.java
@@ -17,9 +17,11 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
         return httpSecurity
                 .csrf().csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
-                .and().sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .and()
                 .authorizeRequests().antMatchers("/actuator/**").authenticated().anyRequest().permitAll()
-                .and().httpBasic(Customizer.withDefaults())
+                .and()
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .httpBasic(Customizer.withDefaults())
                 .build();
     }
 }

--- a/src/main/java/ch/usi/si/seart/config/SecurityConfig.java
+++ b/src/main/java/ch/usi/si/seart/config/SecurityConfig.java
@@ -16,11 +16,18 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
         return httpSecurity
-                .csrf().csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                .csrf()
+                .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
                 .and()
-                .authorizeRequests().antMatchers("/actuator/health").permitAll()
+                .authorizeRequests()
+                .antMatchers("/actuator/health")
+                .permitAll()
                 .and()
-                .authorizeRequests().antMatchers("/actuator/**").authenticated().anyRequest().permitAll()
+                .authorizeRequests()
+                .antMatchers("/actuator/**")
+                .authenticated()
+                .anyRequest()
+                .permitAll()
                 .and()
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .httpBasic(Customizer.withDefaults())

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,8 +19,10 @@ spring.mvc.log-request-details=true
 # Actuator Configuration
 management.endpoints.enabled-by-default=true
 management.endpoints.web.exposure.include=*
-management.endpoint.health.show-details=when_authorized
-management.endpoint.health.show-components=when_authorized
+management.endpoints.web.path-mapping.health=health
+management.endpoint.health.group.details.include=*
+management.endpoint.health.group.details.show-details=when_authorized
+management.endpoint.health.group.details.show-components=when_authorized
 
 # Admin Configuration
 spring.boot.admin.client.enabled=false


### PR DESCRIPTION
Makes two key changes:

1. The back-end server health check now depends on the status as reported by the actuator. This implies that the server health is now determined by not just the HTTP reachability, but also connection to the database, to the GitHub API and disk space. At the same time, precautions have been taken only to expose the `status` publically, while keeping all the details behind an endpoint that enforces authorized-only access.

2. The front-end server now has a very basic NGINX status probe as a `stub_status`. We introduce a new location for said probe, making it only accessible to the `localhost`. This precaution was taken to prevent the leakage of any sensitive information.