### PR TITLE
Add GitHub Personal Access Token validity checks

### DIFF
--- a/.run/springboot/GHSApplication [debug].run.xml
+++ b/.run/springboot/GHSApplication [debug].run.xml
@@ -34,6 +34,10 @@
         <option name="value" value="DEBUG" />
       </param>
       <param>
+        <option name="name" value="logging.level.ch.usi.si.seart" />
+        <option name="value" value="TRACE" />
+      </param>
+      <param>
         <option name="name" value="logging.level.org.flywaydb" />
         <option name="value" value="DEBUG" />
       </param>

--- a/src/main/java/ch/usi/si/seart/config/GraphQlConfig.java
+++ b/src/main/java/ch/usi/si/seart/config/GraphQlConfig.java
@@ -3,6 +3,7 @@ package ch.usi.si.seart.config;
 import ch.usi.si.seart.config.properties.GitHubProperties;
 import ch.usi.si.seart.github.Endpoint;
 import ch.usi.si.seart.github.GitHubGraphQlConnector;
+import ch.usi.si.seart.github.GitHubHttpHeaders;
 import ch.usi.si.seart.github.GitHubTokenManager;
 import ch.usi.si.seart.reactive.LoggingFilterFunction;
 import io.netty.channel.ChannelOption;
@@ -42,7 +43,7 @@ public class GraphQlConfig {
         return WebClient.builder()
                 .baseUrl(Endpoint.GRAPH_QL.toString())
                 .clientConnector(reactorClientHttpConnector)
-                .defaultHeader("X-GitHub-Api-Version", properties.getApiVersion())
+                .defaultHeader(GitHubHttpHeaders.X_GITHUB_API_VERSION, properties.getApiVersion())
                 .filter(loggingFilterFunction)
                 .filter(authorizationFilterFunction)
                 .build();

--- a/src/main/java/ch/usi/si/seart/config/OkHttpClientConfig.java
+++ b/src/main/java/ch/usi/si/seart/config/OkHttpClientConfig.java
@@ -22,7 +22,7 @@ public class OkHttpClientConfig {
     @Bean
     Headers headers(GitHubProperties properties) {
         return Headers.of(
-                HttpHeaders.ACCEPT, "application/vnd.github+json",
+                HttpHeaders.ACCEPT, GitHubMediaTypes.APPLICATION_VND_GITHUB_V3_JSON_VALUE,
                 GitHubHttpHeaders.X_GITHUB_API_VERSION, properties.getApiVersion()
         );
     }

--- a/src/main/java/ch/usi/si/seart/config/OkHttpClientConfig.java
+++ b/src/main/java/ch/usi/si/seart/config/OkHttpClientConfig.java
@@ -15,7 +15,7 @@ import org.springframework.http.HttpHeaders;
 import java.util.concurrent.TimeUnit;
 
 @Configuration
-public class HttpClientConfig {
+public class OkHttpClientConfig {
 
     @Bean
     Headers headers(GitHubProperties properties) {

--- a/src/main/java/ch/usi/si/seart/config/OkHttpClientConfig.java
+++ b/src/main/java/ch/usi/si/seart/config/OkHttpClientConfig.java
@@ -1,6 +1,8 @@
 package ch.usi.si.seart.config;
 
 import ch.usi.si.seart.config.properties.GitHubProperties;
+import ch.usi.si.seart.github.GitHubHttpHeaders;
+import ch.usi.si.seart.github.GitHubMediaTypes;
 import ch.usi.si.seart.github.GitHubRestConnector;
 import ch.usi.si.seart.http.interceptor.HeaderAttachmentInterceptor;
 import ch.usi.si.seart.http.interceptor.LoggingInterceptor;
@@ -21,7 +23,7 @@ public class OkHttpClientConfig {
     Headers headers(GitHubProperties properties) {
         return Headers.of(
                 HttpHeaders.ACCEPT, "application/vnd.github+json",
-                "X-GitHub-Api-Version", properties.getApiVersion()
+                GitHubHttpHeaders.X_GITHUB_API_VERSION, properties.getApiVersion()
         );
     }
 

--- a/src/main/java/ch/usi/si/seart/github/GitHubHttpHeaders.java
+++ b/src/main/java/ch/usi/si/seart/github/GitHubHttpHeaders.java
@@ -1,0 +1,9 @@
+package ch.usi.si.seart.github;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public final class GitHubHttpHeaders {
+
+    public static final String X_GITHUB_API_VERSION = "X-GitHub-Api-Version";
+}

--- a/src/main/java/ch/usi/si/seart/github/GitHubHttpHeaders.java
+++ b/src/main/java/ch/usi/si/seart/github/GitHubHttpHeaders.java
@@ -9,6 +9,10 @@ public final class GitHubHttpHeaders {
 
     public static final String X_GITHUB_API_VERSION = "X-GitHub-Api-Version";
 
+    public static final String X_OAUTH_SCOPES = "X-OAuth-Scopes";
+
+    public static final String X_ACCEPTED_OAUTH_SCOPES = "X-Accepted-OAuth-Scopes";
+
     public static final String X_RATELIMIT_LIMIT = "X-RateLimit-Limit";
 
     public static final String X_RATELIMIT_REMAINING = "X-RateLimit-Remaining";

--- a/src/main/java/ch/usi/si/seart/github/GitHubHttpHeaders.java
+++ b/src/main/java/ch/usi/si/seart/github/GitHubHttpHeaders.java
@@ -8,4 +8,14 @@ public final class GitHubHttpHeaders {
     public static final String X_GITHUB_REQUEST_ID = "X-GitHub-Request-Id";
 
     public static final String X_GITHUB_API_VERSION = "X-GitHub-Api-Version";
+
+    public static final String X_RATELIMIT_LIMIT = "X-RateLimit-Limit";
+
+    public static final String X_RATELIMIT_REMAINING = "X-RateLimit-Remaining";
+
+    public static final String X_RATELIMIT_RESET = "X-RateLimit-Reset";
+
+    public static final String X_RATELIMIT_USED = "X-RateLimit-Used";
+
+    public static final String X_RATELIMIT_RESOURCE = "X-RateLimit-Resource";
 }

--- a/src/main/java/ch/usi/si/seart/github/GitHubHttpHeaders.java
+++ b/src/main/java/ch/usi/si/seart/github/GitHubHttpHeaders.java
@@ -5,5 +5,7 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public final class GitHubHttpHeaders {
 
+    public static final String X_GITHUB_REQUEST_ID = "X-GitHub-Request-Id";
+
     public static final String X_GITHUB_API_VERSION = "X-GitHub-Api-Version";
 }

--- a/src/main/java/ch/usi/si/seart/github/GitHubMediaTypes.java
+++ b/src/main/java/ch/usi/si/seart/github/GitHubMediaTypes.java
@@ -1,0 +1,19 @@
+package ch.usi.si.seart.github;
+
+import lombok.experimental.UtilityClass;
+import org.springframework.http.MediaType;
+
+@UtilityClass
+public class GitHubMediaTypes {
+
+    public static final MediaType APPLICATION_VND_GITHUB_V3_JSON;
+
+    public static final String APPLICATION_VND_GITHUB_V3_JSON_VALUE;
+
+    static {
+        String type = "application";
+        String subtype = "vnd.github.v3+json";
+        APPLICATION_VND_GITHUB_V3_JSON = new MediaType(type, subtype);
+        APPLICATION_VND_GITHUB_V3_JSON_VALUE = type + "/" + subtype;
+    }
+}

--- a/src/main/java/ch/usi/si/seart/github/GitHubRestConnector.java
+++ b/src/main/java/ch/usi/si/seart/github/GitHubRestConnector.java
@@ -359,7 +359,7 @@ public class GitHubRestConnector extends GitHubConnector<RestResponse> {
                      * (3) The repository is taken down due to a TOS violation
                      * (e.g. https://api.github.com/repos/mlwrx1978/freenode/releases)
                      */
-                    String header = "X-RateLimit-Remaining";
+                    String header = GitHubHttpHeaders.X_RATELIMIT_REMAINING;
                     String value = headers.get(header);
                     int remaining = Optional.ofNullable(value)
                             .map(Integer::parseInt)

--- a/src/main/java/ch/usi/si/seart/http/interceptor/LoggingInterceptor.java
+++ b/src/main/java/ch/usi/si/seart/http/interceptor/LoggingInterceptor.java
@@ -1,8 +1,10 @@
 package ch.usi.si.seart.http.interceptor;
 
+import ch.usi.si.seart.github.GitHubHttpHeaders;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.experimental.FieldDefaults;
+import okhttp3.Headers;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -35,6 +37,9 @@ public class LoggingInterceptor implements Interceptor {
         long endNs = System.nanoTime();
         long ms = TimeUnit.NANOSECONDS.toMillis(endNs - startNs);
         log.debug("<<< {} ({}ms)", response.code(), ms);
+        Headers headers = response.headers();
+        String id = headers.get(GitHubHttpHeaders.X_GITHUB_REQUEST_ID);
+        log.trace("[[[ {} ]]]", id);
         return response;
     }
 }

--- a/src/main/java/ch/usi/si/seart/reactive/LoggingFilterFunction.java
+++ b/src/main/java/ch/usi/si/seart/reactive/LoggingFilterFunction.java
@@ -1,10 +1,12 @@
 package ch.usi.si.seart.reactive;
 
+import ch.usi.si.seart.github.GitHubHttpHeaders;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.reactive.function.client.ClientRequest;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
@@ -29,6 +31,9 @@ public class LoggingFilterFunction implements ExchangeFilterFunction {
                     long endNs = System.nanoTime();
                     long ms = TimeUnit.NANOSECONDS.toMillis(endNs - startNs);
                     log.debug("<<< {} ({}ms)", response.rawStatusCode(), ms);
+                    HttpHeaders headers = response.headers().asHttpHeaders();
+                    String id = headers.getFirst(GitHubHttpHeaders.X_GITHUB_REQUEST_ID);
+                    log.trace("[[[ {} ]]]", id);
                 })
                 .doOnError(ex -> {
                     if (log.isDebugEnabled())


### PR DESCRIPTION
The `GitHubTokenManager` is now an `InitializingBean`. Apart from the regular logging and init logic that was previously used in the `@PostConstruct` method, it now also verifies that each specified token:

- Is not expired or invalidated
- Has the correct `repo` scope

This PR also introduces utilities for referencing GitHub-specific headers and media types.