### PR TITLE
Add support for HTTP request identification

### DIFF
--- a/src/main/java/ch/usi/si/seart/config/MainConfig.java
+++ b/src/main/java/ch/usi/si/seart/config/MainConfig.java
@@ -2,13 +2,10 @@ package ch.usi.si.seart.config;
 
 import ch.usi.si.seart.config.properties.StatisticsProperties;
 import ch.usi.si.seart.util.Ranges;
-import ch.usi.si.seart.web.filter.Slf4jMDCLoggingFilter;
-import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.web.filter.ForwardedHeaderFilter;
 
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -49,19 +46,5 @@ public class MainConfig {
         int pageSize = properties.getSuggestionLimit();
         if (pageSize == 0) return Pageable.unpaged();
         return PageRequest.ofSize(pageSize);
-    }
-
-    @Bean
-    public FilterRegistrationBean<ForwardedHeaderFilter> forwardedHeaderFilter() {
-        FilterRegistrationBean<ForwardedHeaderFilter> bean = new FilterRegistrationBean<>();
-        bean.setFilter(new ForwardedHeaderFilter());
-        return bean;
-    }
-
-    @Bean
-    public FilterRegistrationBean<Slf4jMDCLoggingFilter> slf4jMDCLoggingFilter() {
-        FilterRegistrationBean<Slf4jMDCLoggingFilter> bean = new FilterRegistrationBean<>();
-        bean.setFilter(new Slf4jMDCLoggingFilter());
-        return bean;
     }
 }

--- a/src/main/java/ch/usi/si/seart/config/MainConfig.java
+++ b/src/main/java/ch/usi/si/seart/config/MainConfig.java
@@ -2,6 +2,7 @@ package ch.usi.si.seart.config;
 
 import ch.usi.si.seart.config.properties.StatisticsProperties;
 import ch.usi.si.seart.util.Ranges;
+import ch.usi.si.seart.web.filter.Slf4jMDCLoggingFilter;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -54,6 +55,13 @@ public class MainConfig {
     public FilterRegistrationBean<ForwardedHeaderFilter> forwardedHeaderFilter() {
         FilterRegistrationBean<ForwardedHeaderFilter> bean = new FilterRegistrationBean<>();
         bean.setFilter(new ForwardedHeaderFilter());
+        return bean;
+    }
+
+    @Bean
+    public FilterRegistrationBean<Slf4jMDCLoggingFilter> slf4jMDCLoggingFilter() {
+        FilterRegistrationBean<Slf4jMDCLoggingFilter> bean = new FilterRegistrationBean<>();
+        bean.setFilter(new Slf4jMDCLoggingFilter());
         return bean;
     }
 }

--- a/src/main/java/ch/usi/si/seart/config/WebConfig.java
+++ b/src/main/java/ch/usi/si/seart/config/WebConfig.java
@@ -7,9 +7,13 @@ import ch.usi.si.seart.converter.SearchParameterDtoToSpecificationConverter;
 import ch.usi.si.seart.converter.StringToContactsConverter;
 import ch.usi.si.seart.converter.StringToGitExceptionConverter;
 import ch.usi.si.seart.converter.StringToLicensesConverter;
+import ch.usi.si.seart.web.filter.Slf4jMDCLoggingFilter;
 import org.jetbrains.annotations.NotNull;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
+import org.springframework.web.filter.ForwardedHeaderFilter;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -37,5 +41,19 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addConverter(new StringToContactsConverter());
         registry.addConverter(new StringToGitExceptionConverter());
         registry.addConverter(new StringToLicensesConverter());
+    }
+
+    @Bean
+    public FilterRegistrationBean<ForwardedHeaderFilter> forwardedHeaderFilter() {
+        FilterRegistrationBean<ForwardedHeaderFilter> bean = new FilterRegistrationBean<>();
+        bean.setFilter(new ForwardedHeaderFilter());
+        return bean;
+    }
+
+    @Bean
+    public FilterRegistrationBean<Slf4jMDCLoggingFilter> slf4jMDCLoggingFilter() {
+        FilterRegistrationBean<Slf4jMDCLoggingFilter> bean = new FilterRegistrationBean<>();
+        bean.setFilter(new Slf4jMDCLoggingFilter());
+        return bean;
     }
 }

--- a/src/main/java/ch/usi/si/seart/controller/GitRepoController.java
+++ b/src/main/java/ch/usi/si/seart/controller/GitRepoController.java
@@ -13,6 +13,7 @@ import ch.usi.si.seart.service.GitRepoService;
 import ch.usi.si.seart.service.LanguageService;
 import ch.usi.si.seart.service.LicenseService;
 import ch.usi.si.seart.service.StatisticsService;
+import ch.usi.si.seart.web.Headers;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.json.JsonMapper;
@@ -160,8 +161,8 @@ public class GitRepoController {
         resultPage.put("items", dtos);
 
         MultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
-        headers.add("X-Link-Search", searchLinkBuilder.getLinks(request, results));
-        headers.add("X-Link-Download", downloadLinkBuilder.getLinks(request));
+        headers.add(Headers.X_LINK_SEARCH, searchLinkBuilder.getLinks(request, results));
+        headers.add(Headers.X_LINK_DOWNLOAD, downloadLinkBuilder.getLinks(request));
 
         return new ResponseEntity<>(resultPage, headers, HttpStatus.OK);
     }

--- a/src/main/java/ch/usi/si/seart/web/Headers.java
+++ b/src/main/java/ch/usi/si/seart/web/Headers.java
@@ -5,6 +5,8 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class Headers {
 
+    public static final String X_REQUEST_ID = "X-Request-Id";
+
     public static final String X_LINK_SEARCH = "X-Link-Search";
 
     public static final String X_LINK_DOWNLOAD = "X-Link-Download";

--- a/src/main/java/ch/usi/si/seart/web/Headers.java
+++ b/src/main/java/ch/usi/si/seart/web/Headers.java
@@ -1,0 +1,11 @@
+package ch.usi.si.seart.web;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class Headers {
+
+    public static final String X_LINK_SEARCH = "X-Link-Search";
+
+    public static final String X_LINK_DOWNLOAD = "X-Link-Download";
+}

--- a/src/main/java/ch/usi/si/seart/web/filter/Slf4jMDCLoggingFilter.java
+++ b/src/main/java/ch/usi/si/seart/web/filter/Slf4jMDCLoggingFilter.java
@@ -1,0 +1,33 @@
+package ch.usi.si.seart.web.filter;
+
+import ch.usi.si.seart.web.Headers;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.MDC;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+
+
+public class Slf4jMDCLoggingFilter extends OncePerRequestFilter {
+
+    private static final String KEY = "LoggingFilter.UUID";
+
+    @Override
+    protected void doFilterInternal(
+            @NotNull HttpServletRequest request, HttpServletResponse response, FilterChain filterChain
+    ) throws ServletException, IOException {
+        String value = UUID.randomUUID().toString();
+        MDC.put(KEY, value);
+        try {
+            response.setHeader(Headers.X_REQUEST_ID, value);
+            filterChain.doFilter(request, response);
+        } finally {
+            MDC.remove(KEY);
+        }
+    }
+}

--- a/src/main/java/ch/usi/si/seart/web/filter/Slf4jMDCLoggingFilter.java
+++ b/src/main/java/ch/usi/si/seart/web/filter/Slf4jMDCLoggingFilter.java
@@ -32,6 +32,11 @@ public class Slf4jMDCLoggingFilter extends OncePerRequestFilter {
     }
 
     @Override
+    protected boolean isAsyncDispatch(@NotNull HttpServletRequest request) {
+        return false;
+    }
+
+    @Override
     protected boolean shouldNotFilterErrorDispatch() {
         return false;
     }

--- a/src/main/java/ch/usi/si/seart/web/filter/Slf4jMDCLoggingFilter.java
+++ b/src/main/java/ch/usi/si/seart/web/filter/Slf4jMDCLoggingFilter.java
@@ -30,4 +30,9 @@ public class Slf4jMDCLoggingFilter extends OncePerRequestFilter {
             MDC.remove(KEY);
         }
     }
+
+    @Override
+    protected boolean shouldNotFilterErrorDispatch() {
+        return false;
+    }
 }

--- a/src/main/resources/logback.prod.xml
+++ b/src/main/resources/logback.prod.xml
@@ -12,7 +12,7 @@
             value="%d{yyyy-MM-dd HH:mm:ss.SSS} | [%t] | %m%n%wEx"
   />
   <property name="FILE_LOG_PATTERN_MDC_THREAD"
-            value="%d{yyyy-MM-dd HH:mm:ss.SSS} | %X{LoggingFilter.UUID} | [%t] | %m%n%wEx"
+            value="%d{yyyy-MM-dd HH:mm:ss.SSS} | %X{LoggingFilter.UUID:-00000000-0000-0000-0000-000000000000} | [%t] | %m%n%wEx"
   />
 
   <property name="LOGBACK_ROLLINGPOLICY_FILE_NAME_PATTERN" value="${LOG_FILE}.%d{yyyy-MM-dd}.%i.gz" />

--- a/src/main/resources/logback.prod.xml
+++ b/src/main/resources/logback.prod.xml
@@ -5,8 +5,15 @@
 
   <property name="LOG_ROOT" value="logs" />
 
-  <property name="FILE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} | %m%n%wEx" />
-  <property name="FILE_LOG_PATTERN_THREAD" value="%d{yyyy-MM-dd HH:mm:ss.SSS} | [%t] | %m%n%wEx" />
+  <property name="FILE_LOG_PATTERN"
+            value="%d{yyyy-MM-dd HH:mm:ss.SSS} | %m%n%wEx"
+  />
+  <property name="FILE_LOG_PATTERN_THREAD"
+            value="%d{yyyy-MM-dd HH:mm:ss.SSS} | [%t] | %m%n%wEx"
+  />
+  <property name="FILE_LOG_PATTERN_MDC_THREAD"
+            value="%d{yyyy-MM-dd HH:mm:ss.SSS} | %X{LoggingFilter.UUID} | [%t] | %m%n%wEx"
+  />
 
   <property name="LOGBACK_ROLLINGPOLICY_FILE_NAME_PATTERN" value="${LOG_FILE}.%d{yyyy-MM-dd}.%i.gz" />
   <property name="LOGBACK_ROLLINGPOLICY_TOTAL_SIZE_CAP" value="5GB" />
@@ -85,7 +92,7 @@
 
   <appender name="FILE-API" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <encoder>
-      <pattern>${FILE_LOG_PATTERN_THREAD}</pattern>
+      <pattern>${FILE_LOG_PATTERN_MDC_THREAD}</pattern>
       <charset>${FILE_LOG_CHARSET}</charset>
     </encoder>
     <file>${LOG_ROOT}/api/api.log</file>


### PR DESCRIPTION
Each request is now assigned a UUID through a dedicated filter, its value returned to the client within the `X-Request-Id` header. This filter also registers said UUID within SLF4J's Model Diagnostic Context (MDC), allowing us to more easily correlate user requests to the log file. This should enhance the debugging, while making the requests and responses easy to correlate in the log file.