### PR TITLE
Expose more information on the `/actuator/info` endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -319,6 +319,25 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>io.github.git-commit-id</groupId>
+				<artifactId>git-commit-id-maven-plugin</artifactId>
+				<version>7.0.0</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>revision</goal>
+						</goals>
+						<configuration>
+							<commitIdGenerationMode>full</commitIdGenerationMode>
+							<generateGitPropertiesFile>true</generateGitPropertiesFile>
+							<generateGitPropertiesFilename>
+								${project.build.outputDirectory}/git.properties
+							</generateGitPropertiesFilename>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -334,6 +334,25 @@
 							<generateGitPropertiesFilename>
 								${project.build.outputDirectory}/git.properties
 							</generateGitPropertiesFilename>
+							<includeOnlyProperties>
+								<includeOnlyProperty>git.branch</includeOnlyProperty>
+								<includeOnlyProperty>git.build.time</includeOnlyProperty>
+								<includeOnlyProperty>git.build.user.email</includeOnlyProperty>
+								<includeOnlyProperty>git.build.user.name</includeOnlyProperty>
+								<includeOnlyProperty>git.build.version</includeOnlyProperty>
+								<includeOnlyProperty>git.commit.author.time</includeOnlyProperty>
+								<includeOnlyProperty>git.commit.committer.time</includeOnlyProperty>
+								<includeOnlyProperty>git.commit.id.abbrev</includeOnlyProperty>
+								<includeOnlyProperty>git.commit.id.full</includeOnlyProperty>
+								<includeOnlyProperty>git.commit.message.short</includeOnlyProperty>
+								<includeOnlyProperty>git.commit.message.full</includeOnlyProperty>
+								<includeOnlyProperty>git.commit.time</includeOnlyProperty>
+								<includeOnlyProperty>git.commit.user.email</includeOnlyProperty>
+								<includeOnlyProperty>git.commit.user.name</includeOnlyProperty>
+								<includeOnlyProperty>git.remote.origin.url</includeOnlyProperty>
+								<includeOnlyProperty>git.tags</includeOnlyProperty>
+								<includeOnlyProperty>git.total.commit.count</includeOnlyProperty>
+							</includeOnlyProperties>
 						</configuration>
 					</execution>
 				</executions>

--- a/src/main/java/ch/usi/si/seart/actuate/info/SpringInfoContributor.java
+++ b/src/main/java/ch/usi/si/seart/actuate/info/SpringInfoContributor.java
@@ -1,0 +1,20 @@
+package ch.usi.si.seart.actuate.info;
+
+import org.springframework.boot.SpringBootVersion;
+import org.springframework.boot.actuate.info.Info;
+import org.springframework.boot.actuate.info.InfoContributor;
+import org.springframework.core.SpringVersion;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class SpringInfoContributor implements InfoContributor {
+
+    @Override
+    public void contribute(Info.Builder builder) {
+        Map<String, Object> spring = new LinkedHashMap<>(2);
+        spring.put("core-version", SpringVersion.getVersion());
+        spring.put("boot-version", SpringBootVersion.getVersion());
+        builder.withDetail("spring", spring);
+    }
+}

--- a/src/main/java/ch/usi/si/seart/config/ActuatorConfig.java
+++ b/src/main/java/ch/usi/si/seart/config/ActuatorConfig.java
@@ -1,9 +1,15 @@
 package ch.usi.si.seart.config;
 
+import ch.usi.si.seart.actuate.info.SpringInfoContributor;
 import ch.usi.si.seart.github.GitHubAPIHealthIndicator;
+import org.springframework.boot.actuate.autoconfigure.info.ConditionalOnEnabledInfoContributor;
+import org.springframework.boot.actuate.autoconfigure.info.InfoContributorAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.info.InfoContributorFallback;
 import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.actuate.info.InfoContributor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 
 @Configuration
 public class ActuatorConfig {
@@ -11,5 +17,12 @@ public class ActuatorConfig {
     @Bean("gitHubApi")
     public HealthIndicator gitHubApiHealthIndicator() {
         return new GitHubAPIHealthIndicator();
+    }
+
+    @Bean
+    @Order(InfoContributorAutoConfiguration.DEFAULT_ORDER)
+    @ConditionalOnEnabledInfoContributor(value = "spring", fallback = InfoContributorFallback.DISABLE)
+    public InfoContributor applicationInfoContributor() {
+        return new SpringInfoContributor();
     }
 }

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,9 @@
+{
+  "properties": [
+    {
+      "name": "management.info.spring.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether to enable the Spring info contributor."
+    }
+  ]
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,6 +27,7 @@ management.endpoint.health.group.details.show-components=when_authorized
 # Info Configuration
 management.info.os.enabled=true
 management.info.java.enabled=true
+management.info.build.enabled=true
 management.info.git.enabled=true
 management.info.git.mode=full
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,6 +28,7 @@ management.endpoint.health.group.details.show-components=when_authorized
 management.info.os.enabled=true
 management.info.java.enabled=true
 management.info.build.enabled=true
+management.info.spring.enabled=true
 management.info.git.enabled=true
 management.info.git.mode=full
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,6 +24,10 @@ management.endpoint.health.group.details.include=*
 management.endpoint.health.group.details.show-details=when_authorized
 management.endpoint.health.group.details.show-components=when_authorized
 
+# Info Configuration
+management.info.git.enabled=true
+management.info.git.mode=full
+
 # Admin Configuration
 spring.boot.admin.client.enabled=false
 spring.boot.admin.client.url=http://localhost:7777

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,6 +25,7 @@ management.endpoint.health.group.details.show-details=when_authorized
 management.endpoint.health.group.details.show-components=when_authorized
 
 # Info Configuration
+management.info.java.enabled=true
 management.info.git.enabled=true
 management.info.git.mode=full
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,6 +25,7 @@ management.endpoint.health.group.details.show-details=when_authorized
 management.endpoint.health.group.details.show-components=when_authorized
 
 # Info Configuration
+management.info.os.enabled=true
 management.info.java.enabled=true
 management.info.git.enabled=true
 management.info.git.mode=full


### PR DESCRIPTION
It previously only included the `build` information that we used for OpenAPI. This PR also introduces information related to Git, running OS, Java VM and Runtime, and Spring Core/Boot.