### PR TITLE
Add new file log appender to production

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -89,6 +89,7 @@ services:
       - ./logs:/logs
       - ./git/.gitconfig:/root/.gitconfig
     environment:
+      LOGGING_FILE_PATH: /tmp
       LOGGING_CONFIG: classpath:logback.prod.xml
       SPRING_DATASOURCE_URL: jdbc:mysql://gse-database:3306/gse?serverTimezone=UTC&useLegacyDatetimeCode=false&useUnicode=yes&characterEncoding=UTF-8
       SPRING_FLYWAY_ENABLED: 'false'

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -52,7 +52,8 @@ springdoc.swagger-ui.disable-swagger-default-url=true
 
 # Logging Configuration
 logging.config=
-logging.file.name=server.log
+logging.file.path=logs
+logging.file.name=${logging.file.path}/server.log
 logging.level.root=INFO
 
 # JPA Configuration

--- a/src/main/resources/logback.prod.xml
+++ b/src/main/resources/logback.prod.xml
@@ -30,6 +30,18 @@
     </filter>
   </appender>
 
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <encoder>
+      <pattern>${FILE_LOG_PATTERN_THREAD}</pattern>
+      <charset>${FILE_LOG_CHARSET}</charset>
+    </encoder>
+    <append>false</append>
+    <file>/tmp/server.log</file>
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>INFO</level>
+    </filter>
+  </appender>
+
   <appender name="FILE-GITHUB" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <encoder>
       <pattern>${FILE_LOG_PATTERN}</pattern>
@@ -107,6 +119,7 @@
 
   <root level="INFO">
     <appender-ref ref="CONSOLE" />
+    <appender-ref ref="FILE" />
   </root>
   <logger name="ch.usi.si.seart.github" level="TRACE">
     <appender-ref ref="FILE-GITHUB" />


### PR DESCRIPTION
This fixes the issue of a general log being inaccessible from the `/actuator/logfile` endpoint. While the mounted logs retain a lot more detail, this temporary log contains the same output as the console, while being discarded between re-deployments.