### PR TITLE
Add new actuator endpoint for detailed logs: `/actuator/logfiles/**`

### DIFF
--- a/src/main/java/ch/usi/si/seart/actuate/logging/LogFileWebEndpointExtension.java
+++ b/src/main/java/ch/usi/si/seart/actuate/logging/LogFileWebEndpointExtension.java
@@ -11,6 +11,7 @@ import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.ResponseEntity;
 
+import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -29,8 +30,15 @@ public class LogFileWebEndpointExtension {
         if (segments.length == 0) return ResponseEntity.ok(delegate.logFile());
         Path path = Paths.get(LOG_ROOT, segments);
         if (Files.notExists(path)) return ResponseEntity.notFound().build();
-        if (Files.isDirectory(path)) return ResponseEntity.badRequest().build();
-        Resource resource = new FileSystemResource(path.toFile());
+        File file = Files.isRegularFile(path) ? path.toFile() : getDirectoryLogFile(path);
+        if (!file.exists()) return ResponseEntity.notFound().build();
+        Resource resource = new FileSystemResource(file);
         return ResponseEntity.ok(resource);
+    }
+
+    private File getDirectoryLogFile(Path path) {
+        String directory = path.getFileName().toString();
+        String file = directory + ".log";
+        return Paths.get(path.toString(), file).toFile();
     }
 }

--- a/src/main/java/ch/usi/si/seart/actuate/logging/LogFileWebEndpointExtension.java
+++ b/src/main/java/ch/usi/si/seart/actuate/logging/LogFileWebEndpointExtension.java
@@ -28,8 +28,8 @@ public class LogFileWebEndpointExtension {
     public ResponseEntity<Resource> logFile(@Selector(match = Selector.Match.ALL_REMAINING) String... segments) {
         if (segments.length == 0) return ResponseEntity.ok(delegate.logFile());
         Path path = Paths.get(LOG_ROOT, segments);
-        if (Files.isDirectory(path)) return ResponseEntity.badRequest().build();
         if (Files.notExists(path)) return ResponseEntity.notFound().build();
+        if (Files.isDirectory(path)) return ResponseEntity.badRequest().build();
         Resource resource = new FileSystemResource(path.toFile());
         return ResponseEntity.ok(resource);
     }

--- a/src/main/java/ch/usi/si/seart/actuate/logging/LogFileWebEndpointExtension.java
+++ b/src/main/java/ch/usi/si/seart/actuate/logging/LogFileWebEndpointExtension.java
@@ -3,7 +3,6 @@ package ch.usi.si.seart.actuate.logging;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.experimental.FieldDefaults;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 import org.springframework.boot.actuate.endpoint.annotation.Selector;
 import org.springframework.boot.actuate.endpoint.web.annotation.EndpointWebExtension;
@@ -11,16 +10,14 @@ import org.springframework.boot.actuate.logging.LogFileWebEndpoint;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Component;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-@Component
-@EndpointWebExtension(endpoint = LogFileWebEndpoint.class)
-@AllArgsConstructor(onConstructor_ = @Autowired)
+@AllArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+@EndpointWebExtension(endpoint = LogFileWebEndpoint.class)
 public class LogFileWebEndpointExtension {
 
     private static final String LOG_ROOT = "logs";

--- a/src/main/java/ch/usi/si/seart/actuate/logging/LogFileWebEndpointExtension.java
+++ b/src/main/java/ch/usi/si/seart/actuate/logging/LogFileWebEndpointExtension.java
@@ -1,0 +1,39 @@
+package ch.usi.si.seart.actuate.logging;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.boot.actuate.endpoint.annotation.Selector;
+import org.springframework.boot.actuate.endpoint.web.annotation.EndpointWebExtension;
+import org.springframework.boot.actuate.logging.LogFileWebEndpoint;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@Component
+@EndpointWebExtension(endpoint = LogFileWebEndpoint.class)
+@AllArgsConstructor(onConstructor_ = @Autowired)
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+public class LogFileWebEndpointExtension {
+
+    private static final String LOG_ROOT = "logs";
+
+    LogFileWebEndpoint delegate;
+
+    @ReadOperation(produces = "text/plain; charset=UTF-8")
+    public ResponseEntity<Resource> logFile(@Selector(match = Selector.Match.ALL_REMAINING) String... segments) {
+        if (segments.length == 0) return ResponseEntity.ok(delegate.logFile());
+        Path path = Paths.get(LOG_ROOT, segments);
+        if (Files.isDirectory(path)) return ResponseEntity.badRequest().build();
+        if (Files.notExists(path)) return ResponseEntity.notFound().build();
+        Resource resource = new FileSystemResource(path.toFile());
+        return ResponseEntity.ok(resource);
+    }
+}

--- a/src/main/java/ch/usi/si/seart/config/ActuatorConfig.java
+++ b/src/main/java/ch/usi/si/seart/config/ActuatorConfig.java
@@ -1,12 +1,16 @@
 package ch.usi.si.seart.config;
 
 import ch.usi.si.seart.actuate.info.SpringInfoContributor;
+import ch.usi.si.seart.actuate.logging.LogFileWebEndpointExtension;
 import ch.usi.si.seart.github.GitHubAPIHealthIndicator;
+import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.actuate.autoconfigure.info.ConditionalOnEnabledInfoContributor;
 import org.springframework.boot.actuate.autoconfigure.info.InfoContributorAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.info.InfoContributorFallback;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.actuate.info.InfoContributor;
+import org.springframework.boot.actuate.logging.LogFileWebEndpoint;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
@@ -24,5 +28,12 @@ public class ActuatorConfig {
     @ConditionalOnEnabledInfoContributor(value = "spring", fallback = InfoContributorFallback.DISABLE)
     public InfoContributor applicationInfoContributor() {
         return new SpringInfoContributor();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnAvailableEndpoint
+    public LogFileWebEndpointExtension logFileWebEndpointExtension(LogFileWebEndpoint delegate) {
+        return new LogFileWebEndpointExtension(delegate);
     }
 }


### PR DESCRIPTION
This endpoint extension works as follows:

- `/actuator/logfile/` displays the default log file which delegates to the existing endpoint, displaying the general log file (#291)
- `/actuator/logfile/**/{directory}` displays the current open log file for the specified directory.
- `/actuator/logfile/**/{directory}/{file}` displays the specified file within the directory.