### PR TITLE
Enable `/actuator/httptrace` endpoint

### DIFF
--- a/src/main/java/ch/usi/si/seart/config/ActuatorConfig.java
+++ b/src/main/java/ch/usi/si/seart/config/ActuatorConfig.java
@@ -7,12 +7,19 @@ import org.springframework.boot.actuate.autoconfigure.info.InfoContributorAutoCo
 import org.springframework.boot.actuate.autoconfigure.info.InfoContributorFallback;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.actuate.info.InfoContributor;
+import org.springframework.boot.actuate.trace.http.HttpTraceRepository;
+import org.springframework.boot.actuate.trace.http.InMemoryHttpTraceRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 
 @Configuration
 public class ActuatorConfig {
+
+    @Bean
+    public HttpTraceRepository httpTraceRepository() {
+        return new InMemoryHttpTraceRepository();
+    }
 
     @Bean("gitHubApi")
     public HealthIndicator gitHubApiHealthIndicator() {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,6 +24,16 @@ management.endpoint.health.group.details.include=*
 management.endpoint.health.group.details.show-details=when_authorized
 management.endpoint.health.group.details.show-components=when_authorized
 
+# Trace Configuration
+management.trace.http.include[0]=principal
+management.trace.http.include[1]=session-id
+management.trace.http.include[2]=authorization-header
+management.trace.http.include[3]=request_headers
+management.trace.http.include[4]=response-headers
+management.trace.http.include[5]=cookie-headers
+management.trace.http.include[6]=time-taken
+management.trace.http.include[7]=remote-address
+
 # Info Configuration
 management.info.os.enabled=true
 management.info.java.enabled=true


### PR DESCRIPTION
Although we already track requests using a separate log file, this API endpoint will provide a complete and detailed overview of the last 100 requests made to our API, in JSON format.