### PR TITLE
Disable default white-label error pages

### DIFF
--- a/src/main/java/ch/usi/si/seart/controller/ExceptionController.java
+++ b/src/main/java/ch/usi/si/seart/controller/ExceptionController.java
@@ -1,7 +1,6 @@
 package ch.usi.si.seart.controller;
 
 import ch.usi.si.seart.exception.IllegalBoundaryException;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -10,7 +9,6 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 import javax.persistence.EntityNotFoundException;
 import java.util.Map;
 
-@Slf4j
 @ControllerAdvice
 public class ExceptionController extends ResponseEntityExceptionHandler {
 

--- a/src/main/java/ch/usi/si/seart/controller/SimpleErrorController.java
+++ b/src/main/java/ch/usi/si/seart/controller/SimpleErrorController.java
@@ -1,0 +1,23 @@
+package ch.usi.si.seart.controller;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import org.springframework.boot.web.servlet.error.ErrorController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletResponse;
+
+@RestController
+@RequestMapping("${server.error.path:${error.path:/error}}")
+public class SimpleErrorController implements ErrorController {
+
+    @Hidden
+    @RequestMapping
+    public ResponseEntity<Void> error(HttpServletResponse response) {
+        int code = response.getStatus();
+        return code == HttpServletResponse.SC_OK
+                ? ResponseEntity.notFound().build()
+                : ResponseEntity.status(code).build();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 # Server Configuration
 server.servlet.context-path=/api
+server.error.whitelabel.enabled=false
 server.port=8080
 
 # Spring Configuration


### PR DESCRIPTION
Instead of returning the default HTML, which is inconsistent with the site's style, we should just return the HTTP status code. API routes are not meant to be consumed through the browser anyway, so we should not care about how the browser renders the responses.

This also fixes a minor issue that would surface whenever the API redirected to `/error`. The default view engine set up to serve these HTML files would complain about circular references. However, since we no longer render any HTML, the error has been removed.