### PR TITLE
Improve the `/download` endpoint

### DIFF
--- a/src/main/java/ch/usi/si/seart/config/ExportConfig.java
+++ b/src/main/java/ch/usi/si/seart/config/ExportConfig.java
@@ -19,15 +19,9 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
 
 @Configuration
 public class ExportConfig {
-
-    @Bean
-    public Set<String> exportFormats() {
-        return Set.of("csv", "json", "xml");
-    }
 
     @Bean
     DateFormat exportTimeFormat() {

--- a/src/main/java/ch/usi/si/seart/config/HateoasConfig.java
+++ b/src/main/java/ch/usi/si/seart/config/HateoasConfig.java
@@ -1,0 +1,22 @@
+package ch.usi.si.seart.config;
+
+import ch.usi.si.seart.hateoas.DownloadLinkBuilder;
+import ch.usi.si.seart.hateoas.LinkBuilder;
+import ch.usi.si.seart.hateoas.PaginationLinkBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Page;
+
+@Configuration
+public class HateoasConfig {
+
+    @Bean
+    public LinkBuilder<Page<?>> searchLinkBuilder() {
+        return new PaginationLinkBuilder();
+    }
+
+    @Bean
+    public LinkBuilder<Void> downloadLinkBuilder() {
+        return new DownloadLinkBuilder();
+    }
+}

--- a/src/main/java/ch/usi/si/seart/config/JacksonConfig.java
+++ b/src/main/java/ch/usi/si/seart/config/JacksonConfig.java
@@ -51,7 +51,9 @@ public class JacksonConfig {
                 .addModule(new JavaTimeModule())
                 .defaultDateFormat(exportTimeFormat)
                 .enable(JsonGenerator.Feature.IGNORE_UNKNOWN)
+                .enable(CsvGenerator.Feature.ALWAYS_QUOTE_NUMBERS)
                 .enable(CsvGenerator.Feature.ALWAYS_QUOTE_STRINGS)
+                .enable(CsvGenerator.Feature.ALWAYS_QUOTE_EMPTY_STRINGS)
                 .build();
     }
 

--- a/src/main/java/ch/usi/si/seart/config/JacksonConfig.java
+++ b/src/main/java/ch/usi/si/seart/config/JacksonConfig.java
@@ -18,7 +18,6 @@ import java.lang.reflect.Field;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
-import java.util.List;
 
 @Configuration
 public class JacksonConfig {
@@ -69,16 +68,14 @@ public class JacksonConfig {
 
     @Bean
     public CsvSchema csvSchema() {
-        List<String> fields = Arrays.stream(GitRepoDto.class.getDeclaredFields())
+        return Arrays.stream(GitRepoDto.class.getDeclaredFields())
                 .map(Field::getName)
-                .toList();
-
-        CsvSchema.Builder schemaBuilder = CsvSchema.builder();
-        for (String field : fields) {
-            schemaBuilder.addColumn(field);
-        }
-
-        // TODO: Add option for CSV comments
-        return schemaBuilder.build().withHeader();
+                .reduce(
+                        CsvSchema.builder(),
+                        CsvSchema.Builder::addColumn,
+                        (first, second) -> first.addColumns(second::getColumns)
+                )
+                .build()
+                .withHeader();
     }
 }

--- a/src/main/java/ch/usi/si/seart/config/JacksonConfig.java
+++ b/src/main/java/ch/usi/si/seart/config/JacksonConfig.java
@@ -21,7 +21,7 @@ import java.util.Arrays;
 import java.util.List;
 
 @Configuration
-public class ExportConfig {
+public class JacksonConfig {
 
     @Bean
     DateFormat exportTimeFormat() {

--- a/src/main/java/ch/usi/si/seart/config/WebConfig.java
+++ b/src/main/java/ch/usi/si/seart/config/WebConfig.java
@@ -5,6 +5,7 @@ import ch.usi.si.seart.converter.JsonObjectToGitCommitConverter;
 import ch.usi.si.seart.converter.JsonObjectToGitRepoMetricConverter;
 import ch.usi.si.seart.converter.SearchParameterDtoToSpecificationConverter;
 import ch.usi.si.seart.converter.StringToContactsConverter;
+import ch.usi.si.seart.converter.StringToExportFormatConverter;
 import ch.usi.si.seart.converter.StringToGitExceptionConverter;
 import ch.usi.si.seart.converter.StringToLicensesConverter;
 import ch.usi.si.seart.web.filter.Slf4jMDCLoggingFilter;
@@ -39,6 +40,7 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addConverter(new JsonObjectToGitRepoMetricConverter());
         registry.addConverter(new SearchParameterDtoToSpecificationConverter());
         registry.addConverter(new StringToContactsConverter());
+        registry.addConverter(new StringToExportFormatConverter());
         registry.addConverter(new StringToGitExceptionConverter());
         registry.addConverter(new StringToLicensesConverter());
     }

--- a/src/main/java/ch/usi/si/seart/config/WebConfig.java
+++ b/src/main/java/ch/usi/si/seart/config/WebConfig.java
@@ -1,5 +1,6 @@
 package ch.usi.si.seart.config;
 
+import ch.usi.si.seart.converter.ExportFormatToJsonFactoryConverter;
 import ch.usi.si.seart.converter.GitRepoToDtoConverter;
 import ch.usi.si.seart.converter.JsonObjectToGitCommitConverter;
 import ch.usi.si.seart.converter.JsonObjectToGitRepoMetricConverter;
@@ -35,6 +36,7 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addFormatters(@NotNull final FormatterRegistry registry) {
+        registry.addConverter(new ExportFormatToJsonFactoryConverter());
         registry.addConverter(new GitRepoToDtoConverter());
         registry.addConverter(new JsonObjectToGitCommitConverter());
         registry.addConverter(new JsonObjectToGitRepoMetricConverter());

--- a/src/main/java/ch/usi/si/seart/config/WebConfig.java
+++ b/src/main/java/ch/usi/si/seart/config/WebConfig.java
@@ -1,6 +1,5 @@
 package ch.usi.si.seart.config;
 
-import ch.usi.si.seart.converter.ExportFormatToJsonFactoryConverter;
 import ch.usi.si.seart.converter.GitRepoToDtoConverter;
 import ch.usi.si.seart.converter.JsonObjectToGitCommitConverter;
 import ch.usi.si.seart.converter.JsonObjectToGitRepoMetricConverter;
@@ -36,7 +35,6 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addFormatters(@NotNull final FormatterRegistry registry) {
-        registry.addConverter(new ExportFormatToJsonFactoryConverter());
         registry.addConverter(new GitRepoToDtoConverter());
         registry.addConverter(new JsonObjectToGitCommitConverter());
         registry.addConverter(new JsonObjectToGitRepoMetricConverter());

--- a/src/main/java/ch/usi/si/seart/controller/GitRepoController.java
+++ b/src/main/java/ch/usi/si/seart/controller/GitRepoController.java
@@ -61,7 +61,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.xml.namespace.QName;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -69,6 +68,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.zip.GZIPOutputStream;
 
 @SuppressWarnings("ConstantConditions")
 @Slf4j
@@ -184,11 +184,11 @@ public class GitRepoController {
             SearchParameterDto searchParameterDto,
             HttpServletResponse response
     ) throws IOException {
-        response.setHeader(HttpHeaders.CONTENT_TYPE, format.getMediaType().toString());
-        response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename=results." + format);
+        response.setHeader(HttpHeaders.CONTENT_TYPE, "application/gzip");
+        response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename=results." + format + ".gz");
         Specification<GitRepo> specification = conversionService.convert(searchParameterDto, Specification.class);
         JsonFactory factory = conversionService.convert(format, JsonFactory.class);
-        OutputStream outputStream = response.getOutputStream();
+        GZIPOutputStream outputStream = new GZIPOutputStream(response.getOutputStream());
         @Cleanup JsonGenerator jsonGenerator = factory.createGenerator(outputStream);
         @Cleanup Stream<GitRepoDto> results = gitRepoService.streamBy(specification)
                 .map(gitRepo -> {

--- a/src/main/java/ch/usi/si/seart/controller/GitRepoController.java
+++ b/src/main/java/ch/usi/si/seart/controller/GitRepoController.java
@@ -57,9 +57,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.xml.namespace.QName;
+import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -188,8 +190,10 @@ public class GitRepoController {
         response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename=results." + format + ".gz");
         Specification<GitRepo> specification = conversionService.convert(searchParameterDto, Specification.class);
         JsonFactory factory = conversionService.convert(format, JsonFactory.class);
-        GZIPOutputStream outputStream = new GZIPOutputStream(response.getOutputStream());
-        @Cleanup JsonGenerator jsonGenerator = factory.createGenerator(outputStream);
+        ServletOutputStream servletOutputStream = response.getOutputStream();
+        BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(servletOutputStream);
+        GZIPOutputStream gzipOutputStream = new GZIPOutputStream(bufferedOutputStream);
+        @Cleanup JsonGenerator jsonGenerator = factory.createGenerator(gzipOutputStream);
         @Cleanup Stream<GitRepoDto> results = gitRepoService.streamBy(specification)
                 .map(gitRepo -> {
                     GitRepoDto dto = conversionService.convert(gitRepo, GitRepoDto.class);

--- a/src/main/java/ch/usi/si/seart/controller/GitRepoController.java
+++ b/src/main/java/ch/usi/si/seart/controller/GitRepoController.java
@@ -3,8 +3,7 @@ package ch.usi.si.seart.controller;
 import ch.usi.si.seart.dto.GitRepoCsvDto;
 import ch.usi.si.seart.dto.GitRepoDto;
 import ch.usi.si.seart.dto.SearchParameterDto;
-import ch.usi.si.seart.hateoas.DownloadLinkBuilder;
-import ch.usi.si.seart.hateoas.SearchLinkBuilder;
+import ch.usi.si.seart.hateoas.LinkBuilder;
 import ch.usi.si.seart.model.GitRepo;
 import ch.usi.si.seart.model.GitRepo_;
 import ch.usi.si.seart.model.Language;
@@ -118,8 +117,8 @@ public class GitRepoController {
     @PersistenceContext
     EntityManager entityManager;
 
-    SearchLinkBuilder searchLinkBuilder;
-    DownloadLinkBuilder downloadLinkBuilder;
+    LinkBuilder<Page<?>> searchLinkBuilder;
+    LinkBuilder<Void> downloadLinkBuilder;
 
     @SuppressWarnings("unchecked")
     @GetMapping(value = "/search", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/ch/usi/si/seart/controller/GitRepoController.java
+++ b/src/main/java/ch/usi/si/seart/controller/GitRepoController.java
@@ -150,7 +150,7 @@ public class GitRepoController {
 
         List<GitRepoDto> dtos = List.of(
                 conversionService.convert(
-                        results.getContent().toArray(new GitRepo[0]), GitRepoDto[].class
+                        results.getContent().toArray(GitRepo[]::new), GitRepoDto[].class
                 )
         );
 

--- a/src/main/java/ch/usi/si/seart/controller/GitRepoController.java
+++ b/src/main/java/ch/usi/si/seart/controller/GitRepoController.java
@@ -205,14 +205,8 @@ public class GitRepoController {
         if (jsonGenerator instanceof CsvGenerator csvGenerator) {
             csvGenerator.setCodec(csvMapper);
             csvGenerator.setSchema(csvSchema);
-            csvGenerator.configure(JsonGenerator.Feature.IGNORE_UNKNOWN, true);
-            csvGenerator.configure(CsvGenerator.Feature.ALWAYS_QUOTE_NUMBERS, true);
-            csvGenerator.configure(CsvGenerator.Feature.ALWAYS_QUOTE_STRINGS, true);
-            csvGenerator.configure(CsvGenerator.Feature.ALWAYS_QUOTE_EMPTY_STRINGS, true);
         } else if (jsonGenerator instanceof ToXmlGenerator xmlGenerator) {
             xmlGenerator.setCodec(xmlMapper);
-            xmlGenerator.configure(ToXmlGenerator.Feature.WRITE_XML_1_1, true);
-            xmlGenerator.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true);
         } else {
             jsonGenerator.setCodec(jsonMapper);
         }

--- a/src/main/java/ch/usi/si/seart/converter/ExportFormatToJsonFactoryConverter.java
+++ b/src/main/java/ch/usi/si/seart/converter/ExportFormatToJsonFactoryConverter.java
@@ -2,20 +2,37 @@ package ch.usi.si.seart.converter;
 
 import ch.usi.si.seart.web.ExportFormat;
 import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.dataformat.csv.CsvFactory;
-import com.fasterxml.jackson.dataformat.xml.XmlFactory;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.dataformat.csv.CsvMapper;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
 
+@Component
+@AllArgsConstructor(onConstructor_ = @Autowired)
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class ExportFormatToJsonFactoryConverter implements Converter<ExportFormat, JsonFactory> {
+
+    @Qualifier("csvMapper")
+    CsvMapper csvMapper;
+    @Qualifier("jsonMapper")
+    JsonMapper jsonMapper;
+    @Qualifier("xmlMapper")
+    XmlMapper xmlMapper;
 
     @Override
     @NonNull
     public JsonFactory convert(@NonNull ExportFormat source) {
         return switch (source) {
-            case CSV -> new CsvFactory();
-            case JSON -> new JsonFactory();
-            case XML -> new XmlFactory();
+            case CSV -> csvMapper.getFactory().copy();
+            case JSON -> jsonMapper.getFactory().copy();
+            case XML -> xmlMapper.getFactory().copy();
         };
     }
 }

--- a/src/main/java/ch/usi/si/seart/converter/ExportFormatToJsonFactoryConverter.java
+++ b/src/main/java/ch/usi/si/seart/converter/ExportFormatToJsonFactoryConverter.java
@@ -1,0 +1,21 @@
+package ch.usi.si.seart.converter;
+
+import ch.usi.si.seart.web.ExportFormat;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.dataformat.csv.CsvFactory;
+import com.fasterxml.jackson.dataformat.xml.XmlFactory;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.lang.NonNull;
+
+public class ExportFormatToJsonFactoryConverter implements Converter<ExportFormat, JsonFactory> {
+
+    @Override
+    @NonNull
+    public JsonFactory convert(@NonNull ExportFormat source) {
+        return switch (source) {
+            case CSV -> new CsvFactory();
+            case JSON -> new JsonFactory();
+            case XML -> new XmlFactory();
+        };
+    }
+}

--- a/src/main/java/ch/usi/si/seart/converter/StringToExportFormatConverter.java
+++ b/src/main/java/ch/usi/si/seart/converter/StringToExportFormatConverter.java
@@ -1,0 +1,14 @@
+package ch.usi.si.seart.converter;
+
+import ch.usi.si.seart.web.ExportFormat;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.lang.NonNull;
+
+public class StringToExportFormatConverter implements Converter<String, ExportFormat> {
+
+    @Override
+    @NonNull
+    public ExportFormat convert(@NonNull String source) {
+        return ExportFormat.valueOf(source.toUpperCase());
+    }
+}

--- a/src/main/java/ch/usi/si/seart/dto/SearchParameterDto.java
+++ b/src/main/java/ch/usi/si/seart/dto/SearchParameterDto.java
@@ -16,7 +16,6 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.util.ObjectUtils;
 
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Map;
 
 @Getter
@@ -84,39 +83,6 @@ public class SearchParameterDto {
         Map<String, Object> map = mapper.convertValue(this, TYPE_REFERENCE);
         map.values().removeIf(ObjectUtils::isEmpty);
         return map;
-    }
-
-    public Map<String, Object> toParameterMap() {
-        Map<String, Object> parameters = new HashMap<>();
-
-        parameters.put("name", name);
-        parameters.put("nameEquals", nameEquals);
-        parameters.put("language", language);
-        parameters.put("license", license);
-        parameters.put("label", label);
-        parameters.put("topic", topic);
-        parameters.put("commits", getCommits());
-        parameters.put("contributors", getContributors());
-        parameters.put("issues", getIssues());
-        parameters.put("pulls", getPulls());
-        parameters.put("branches", getBranches());
-        parameters.put("releases", getReleases());
-        parameters.put("stars", getStars());
-        parameters.put("watchers", getWatchers());
-        parameters.put("forks", getForks());
-        parameters.put("codeLines", getCodeLines());
-        parameters.put("commentLines", getCommentLines());
-        parameters.put("nonBlankLines", getNonBlankLines());
-        parameters.put("created", getCreated());
-        parameters.put("committed", getCommitted());
-        parameters.put("excludeForks", excludeForks);
-        parameters.put("onlyForks", onlyForks);
-        parameters.put("hasIssues", hasIssues);
-        parameters.put("hasPulls", hasPulls);
-        parameters.put("hasWiki", hasWiki);
-        parameters.put("hasLicense", hasLicense);
-
-        return parameters;
     }
 
     @JsonIgnore

--- a/src/main/java/ch/usi/si/seart/dto/SearchParameterDto.java
+++ b/src/main/java/ch/usi/si/seart/dto/SearchParameterDto.java
@@ -1,6 +1,7 @@
 package ch.usi.si.seart.dto;
 
 import ch.usi.si.seart.util.Ranges;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -113,71 +114,85 @@ public class SearchParameterDto {
         return parameters;
     }
 
+    @JsonIgnore
     @Schema(hidden = true)
     public Range<Long> getCommits() {
         return Ranges.closed(commitsMin, commitsMax);
     }
 
+    @JsonIgnore
     @Schema(hidden = true)
     public Range<Long> getContributors() {
         return Ranges.closed(contributorsMin, contributorsMax);
     }
 
+    @JsonIgnore
     @Schema(hidden = true)
     public Range<Long> getIssues() {
         return Ranges.closed(issuesMin, issuesMax);
     }
 
+    @JsonIgnore
     @Schema(hidden = true)
     public Range<Long> getPulls() {
         return Ranges.closed(pullsMin, pullsMax);
     }
 
+    @JsonIgnore
     @Schema(hidden = true)
     public Range<Long> getBranches() {
         return Ranges.closed(branchesMin, branchesMax);
     }
 
+    @JsonIgnore
     @Schema(hidden = true)
     public Range<Long> getReleases() {
         return Ranges.closed(releasesMin, releasesMax);
     }
 
+    @JsonIgnore
     @Schema(hidden = true)
     public Range<Long> getStars() {
         return Ranges.closed(starsMin, starsMax);
     }
 
+    @JsonIgnore
     @Schema(hidden = true)
     public Range<Long> getWatchers() {
         return Ranges.closed(watchersMin, watchersMax);
     }
 
+    @JsonIgnore
     @Schema(hidden = true)
     public Range<Long> getForks() {
         return Ranges.closed(forksMin, forksMax);
     }
 
+    @JsonIgnore
     @Schema(hidden = true)
     public Range<Date> getCreated() {
         return Ranges.closed(createdMin, createdMax);
     }
 
+    @JsonIgnore
     @Schema(hidden = true)
     public Range<Date> getCommitted() {
         return Ranges.closed(committedMin, committedMax);
     }
 
+    @JsonIgnore
     @Schema(hidden = true)
     public Range<Long> getCodeLines() {
         return Ranges.closed(codeLinesMin, codeLinesMax);
     }
 
+    @JsonIgnore
     @Schema(hidden = true)
     public Range<Long> getCommentLines() {
         return Ranges.closed(commentLinesMin, commentLinesMax);
     }
 
+    @JsonIgnore
     @Schema(hidden = true)
     public Range<Long> getNonBlankLines() {
         return Ranges.closed(nonBlankLinesMin, nonBlankLinesMax);

--- a/src/main/java/ch/usi/si/seart/dto/SearchParameterDto.java
+++ b/src/main/java/ch/usi/si/seart/dto/SearchParameterDto.java
@@ -16,7 +16,9 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.util.ObjectUtils;
 
 import java.util.Date;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Getter
 @Setter
@@ -80,9 +82,16 @@ public class SearchParameterDto {
     Boolean hasLicense = false;
 
     public Map<String, Object> toMap() {
-        Map<String, Object> map = mapper.convertValue(this, TYPE_REFERENCE);
-        map.values().removeIf(ObjectUtils::isEmpty);
-        return map;
+        return mapper.convertValue(this, TYPE_REFERENCE)
+                .entrySet()
+                .stream()
+                .filter(entry -> !ObjectUtils.isEmpty(entry.getValue()))
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        Map.Entry::getValue,
+                        (first, second) -> first,
+                        LinkedHashMap::new
+                ));
     }
 
     @JsonIgnore

--- a/src/main/java/ch/usi/si/seart/dto/SearchParameterDto.java
+++ b/src/main/java/ch/usi/si/seart/dto/SearchParameterDto.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.FieldDefaults;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.util.ObjectUtils;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -26,7 +27,10 @@ import java.util.Map;
 public class SearchParameterDto {
 
     private static final ObjectMapper mapper = new ObjectMapper();
-    
+
+    private static final TypeReference<Map<String, Object>> TYPE_REFERENCE = new TypeReference<>() {
+    };
+
     String name = "";
     Boolean nameEquals = false;
     String language = "";
@@ -77,8 +81,9 @@ public class SearchParameterDto {
     Boolean hasLicense = false;
 
     public Map<String, Object> toMap() {
-        return mapper.convertValue(this, new TypeReference<>() {
-        });
+        Map<String, Object> map = mapper.convertValue(this, TYPE_REFERENCE);
+        map.values().removeIf(ObjectUtils::isEmpty);
+        return map;
     }
 
     public Map<String, Object> toParameterMap() {

--- a/src/main/java/ch/usi/si/seart/function/CheckedRunnable.java
+++ b/src/main/java/ch/usi/si/seart/function/CheckedRunnable.java
@@ -1,0 +1,14 @@
+package ch.usi.si.seart.function;
+
+/**
+ * Alternative version of {@link Runnable} that can throw an exception.
+ *
+ * @param <E> the type of exception that the runnable can throw.
+ * @see Runnable
+ * @author Ozren Dabić
+ */
+@FunctionalInterface
+public interface CheckedRunnable<E extends Exception> {
+
+    void run() throws E;
+}

--- a/src/main/java/ch/usi/si/seart/function/IOExceptingRunnable.java
+++ b/src/main/java/ch/usi/si/seart/function/IOExceptingRunnable.java
@@ -1,0 +1,31 @@
+package ch.usi.si.seart.function;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Objects;
+
+/**
+ * Represents a {@link CheckedRunnable} that can throw an {@link IOException}.
+ */
+public interface IOExceptingRunnable extends CheckedRunnable<IOException> {
+
+    /**
+     * Returns a wrapped {@link Runnable} that will execute
+     * the same operations, albeit throwing an unchecked
+     * counterpart of {@link IOException}.
+     *
+     * @param runnable the runnable to wrap
+     * @return an identical runnable that may
+     * throw an {@link UncheckedIOException} instead
+     */
+    static Runnable toUnchecked(CheckedRunnable<IOException> runnable) {
+        Objects.requireNonNull(runnable, "Runnable must not be null!");
+        return () -> {
+            try {
+                runnable.run();
+            } catch (IOException ex) {
+                throw new UncheckedIOException(ex);
+            }
+        };
+    }
+}

--- a/src/main/java/ch/usi/si/seart/hateoas/DownloadLinkBuilder.java
+++ b/src/main/java/ch/usi/si/seart/hateoas/DownloadLinkBuilder.java
@@ -2,12 +2,8 @@ package ch.usi.si.seart.hateoas;
 
 import ch.usi.si.seart.controller.GitRepoController;
 import ch.usi.si.seart.dto.SearchParameterDto;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
+import ch.usi.si.seart.web.ExportFormat;
 import lombok.SneakyThrows;
-import lombok.experimental.FieldDefaults;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.UriTemplate;
 import org.springframework.stereotype.Component;
@@ -18,16 +14,11 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.lang.reflect.Method;
 import java.net.URI;
-import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Component("downloadLinkBuilder")
-@AllArgsConstructor(onConstructor_ = @Autowired)
-@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class DownloadLinkBuilder extends LinkBuilder<Void> {
-
-    @Qualifier("exportFormats")
-    Set<String> exportFormats;
 
     @Override
     protected Class<?> getControllerClass() {
@@ -39,7 +30,7 @@ public class DownloadLinkBuilder extends LinkBuilder<Void> {
     protected Method getControllerMethod() {
         return getControllerClass().getMethod(
                 "downloadRepos",
-                String.class,
+                ExportFormat.class,
                 SearchParameterDto.class,
                 HttpServletResponse.class
         );
@@ -49,7 +40,7 @@ public class DownloadLinkBuilder extends LinkBuilder<Void> {
     public String getLinks(HttpServletRequest request, Void ignored) {
         MultiValueMap<String, String> parameters = extractParameters(request);
         UriTemplate template = getUriTemplate();
-        return exportFormats.stream()
+        return Stream.of(ExportFormat.values())
                 .map(format -> {
                     URI base = template.expand(format);
                     URI uri = UriComponentsBuilder.fromUri(base)
@@ -58,9 +49,9 @@ public class DownloadLinkBuilder extends LinkBuilder<Void> {
                             .replaceQueryParam("sort")
                             .build(true)
                             .toUri();
-                    Link link = Link.of(uri.toString(), format);
-                    return link.toString();
+                    return Link.of(uri.toString(), format.toString());
                 })
+                .map(Link::toString)
                 .collect(Collectors.joining(","));
     }
 }

--- a/src/main/java/ch/usi/si/seart/hateoas/DownloadLinkBuilder.java
+++ b/src/main/java/ch/usi/si/seart/hateoas/DownloadLinkBuilder.java
@@ -6,7 +6,6 @@ import ch.usi.si.seart.web.ExportFormat;
 import lombok.SneakyThrows;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.UriTemplate;
-import org.springframework.stereotype.Component;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -17,7 +16,6 @@ import java.net.URI;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-@Component("downloadLinkBuilder")
 public class DownloadLinkBuilder extends LinkBuilder<Void> {
 
     @Override

--- a/src/main/java/ch/usi/si/seart/hateoas/PaginationLinkBuilder.java
+++ b/src/main/java/ch/usi/si/seart/hateoas/PaginationLinkBuilder.java
@@ -8,7 +8,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.hateoas.IanaLinkRelations;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.UriTemplate;
-import org.springframework.stereotype.Component;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -19,8 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Component("searchLinkBuilder")
-public class SearchLinkBuilder extends LinkBuilder<Page<?>> {
+public class PaginationLinkBuilder extends LinkBuilder<Page<?>> {
 
     @Override
     protected Class<?> getControllerClass() {

--- a/src/main/java/ch/usi/si/seart/model/GitRepo.java
+++ b/src/main/java/ch/usi/si/seart/model/GitRepo.java
@@ -54,11 +54,11 @@ public class GitRepo {
     @Column(name = "id")
     Long id;
 
-    @ManyToOne(optional = false)
+    @ManyToOne(cascade = CascadeType.DETACH, optional = false)
     @JoinColumn(name = "language_id")
     Language mainLanguage;
 
-    @ManyToOne
+    @ManyToOne(cascade = CascadeType.DETACH)
     @JoinColumn(name = "license_id")
     License license;
 

--- a/src/main/java/ch/usi/si/seart/web/ExportFormat.java
+++ b/src/main/java/ch/usi/si/seart/web/ExportFormat.java
@@ -1,21 +1,8 @@
 package ch.usi.si.seart.web;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.experimental.FieldDefaults;
-import org.springframework.http.MediaType;
-
-@Getter
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
-@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public enum ExportFormat {
 
-    CSV(new MediaType("text", "csv")),
-    JSON(MediaType.APPLICATION_JSON),
-    XML(MediaType.APPLICATION_XML);
-
-    MediaType mediaType;
+    CSV, JSON, XML;
 
     @Override
     public String toString() {

--- a/src/main/java/ch/usi/si/seart/web/ExportFormat.java
+++ b/src/main/java/ch/usi/si/seart/web/ExportFormat.java
@@ -1,0 +1,24 @@
+package ch.usi.si.seart.web;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.experimental.FieldDefaults;
+import org.springframework.http.MediaType;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+public enum ExportFormat {
+
+    CSV(new MediaType("text", "csv")),
+    JSON(MediaType.APPLICATION_JSON),
+    XML(MediaType.APPLICATION_XML);
+
+    MediaType mediaType;
+
+    @Override
+    public String toString() {
+        return name().toLowerCase();
+    }
+}


### PR DESCRIPTION
What started as a need for a simple change quickly escalated into a complete refactoring once a plethora of hidden issues was discovered. Here's what this PR includes:

- The supported export formats now have their own enum `ExportFormat`;
- The endpoint has been broken up into smaller, more readable steps;
- The entity manager cache is periodically cleared to allow for more efficient GC;
- The `JsonGenerator` is now periodically flushed during writes;
- `JsonFactory` instances are now obtained from a dedicated converter;
- Generated datasets are now _always_ compressed;
- Fixed incorrect request parameters included in JSON and XML exports;
- Rename `ExportConfig` to `JacksonConfig`;
- Added `HateoasConfig` for creating link builder beans;
- HATEOAS link builders are now non-component classes.