### PR TITLE
Fix minor bug that prevented the addition of new `Language` mining targets

### DIFF
--- a/src/main/java/ch/usi/si/seart/model/Language.java
+++ b/src/main/java/ch/usi/si/seart/model/Language.java
@@ -66,6 +66,7 @@ public class Language {
     Progress progress;
 
     @Getter
+    @Builder
     @NoArgsConstructor
     @AllArgsConstructor
     @Entity
@@ -82,11 +83,13 @@ public class Language {
         @JoinColumn(name = "language_id")
         Language language;
 
+        @Builder.Default
         @Column(name = "mined")
-        Long mined;
+        Long mined = 0L;
 
+        @Builder.Default
         @Column(name = "analyzed")
-        Long analyzed;
+        Long analyzed = 0L;
 
         @Override
         public boolean equals(Object o) {

--- a/src/main/java/ch/usi/si/seart/model/Language.java
+++ b/src/main/java/ch/usi/si/seart/model/Language.java
@@ -12,6 +12,7 @@ import lombok.experimental.FieldDefaults;
 import org.hibernate.Hibernate;
 import org.hibernate.annotations.Immutable;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -58,11 +59,27 @@ public class Language {
     Set<GitRepoMetric> metrics = new HashSet<>();
 
     @PrimaryKeyJoinColumn
-    @OneToOne(mappedBy = "language")
+    @OneToOne(
+            mappedBy = "language",
+            cascade = {
+                CascadeType.PERSIST,
+                CascadeType.MERGE,
+                CascadeType.REFRESH,
+                CascadeType.DETACH
+            }
+    )
     Statistics statistics;
 
     @PrimaryKeyJoinColumn
-    @OneToOne(mappedBy = "language")
+    @OneToOne(
+            mappedBy = "language",
+            cascade = {
+                CascadeType.PERSIST,
+                CascadeType.MERGE,
+                CascadeType.REFRESH,
+                CascadeType.DETACH
+            }
+    )
     Progress progress;
 
     @Getter

--- a/src/main/java/ch/usi/si/seart/service/LanguageService.java
+++ b/src/main/java/ch/usi/si/seart/service/LanguageService.java
@@ -124,13 +124,18 @@ public interface LanguageService extends NamedEntityService<Language> {
                                 ),
                                 () -> {
                                     log.debug("Initializing progress for {} to default start date...", name);
-                                    languageProgressRepository.save(
-                                            Language.Progress.builder()
-                                                    .id(language.getId())
-                                                    .language(language)
-                                                    .checkpoint(defaultCheckpoint)
-                                                    .build()
-                                    );
+                                    Language.Progress progress = Language.Progress.builder()
+                                            .id(language.getId())
+                                            .language(language)
+                                            .checkpoint(defaultCheckpoint)
+                                            .build();
+                                    Language.Statistics statistics = Language.Statistics.builder()
+                                            .id(language.getId())
+                                            .language(language)
+                                            .build();
+                                    language.setProgress(progress);
+                                    language.setStatistics(statistics);
+                                    languageRepository.save(language);
                                 });
             }
         }


### PR DESCRIPTION
There were some missing operations and JPA annotations that prevented new languages from being added to the mining pool. This PR addresses this problem.