### PR TITLE
Add MySQL logging to files in custom database image

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     restart: "always"
     volumes:
       - data:/var/lib/mysql
+      - ./logs/database:/var/log/mysql
       - ./mysql.cnf:/etc/mysql/conf.d/mysql.cnf
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: yes

--- a/docker-compose/mysql.cnf
+++ b/docker-compose/mysql.cnf
@@ -3,6 +3,13 @@ event-scheduler=on
 default-time-zone="+00:00"
 group-concat-max-len=10000
 log-bin-trust-function-creators=1
+general-log=on
+general-log-file=/var/log/mysql/mysql.log
+log-error=/var/log/mysql/mysql_error.log
+slow-query-log=on
+slow-query-log-file=/var/log/mysql/mysql_slow.log
+long-query-time=3
+log-queries-not-using-indexes=on
 
 [mysqldump]
 quick

--- a/docker/database/Dockerfile
+++ b/docker/database/Dockerfile
@@ -1,6 +1,15 @@
 FROM mysql:8.3.0
 LABEL maintainer="Ozren Dabić (dabico@usi.ch)"
 
+WORKDIR /
+
+RUN microdnf update --best \
+                    --refresh \
+                    --nodocs \
+                    --noplugins && \
+    microdnf install -y logrotate && \
+    microdnf clean all
+
 WORKDIR /docker-entrypoint-initdb.d
 
 ADD "https://www.dropbox.com/scl/fi/5eku4c65on1g26rnjzsx1/gse.sql.gz?rlkey=08l0sfvyj29b2wfvzw5vuuay4&dl=1" gse.sql.gz

--- a/docker/database/Dockerfile
+++ b/docker/database/Dockerfile
@@ -10,6 +10,36 @@ RUN microdnf update --best \
     microdnf install -y logrotate && \
     microdnf clean all
 
+# https://mariadb.com/kb/en/rotating-logs-on-unix-and-linux
+COPY <<-EOF /etc/logrotate.d/mysql
+/var/log/mysql/* {
+        # Permissions
+        su mysql mysql
+        create 660 mysql mysql
+        missingok
+        # Size settings
+        minsize 1M
+        maxsize 100M
+        notifempty
+        # Rotate
+        daily
+        dateext
+        dateformat .%Y_%m_%d
+        maxage 180
+        # Options
+        copytruncate
+        compress
+        delaycompress
+        # Scripts
+        sharedscripts
+        postrotate
+        if test -x /usr/bin/mysqladmin && /usr/bin/mysqladmin ping &>/dev/null
+                then /usr/bin/mysqladmin --defaults-file=/etc/mysql/conf.d/mysql.cnf flush-logs
+        fi
+        endscript
+}
+EOF
+
 WORKDIR /docker-entrypoint-initdb.d
 
 ADD "https://www.dropbox.com/scl/fi/5eku4c65on1g26rnjzsx1/gse.sql.gz?rlkey=08l0sfvyj29b2wfvzw5vuuay4&dl=1" gse.sql.gz

--- a/docker/database/Dockerfile
+++ b/docker/database/Dockerfile
@@ -7,7 +7,7 @@ RUN microdnf update --best \
                     --refresh \
                     --nodocs \
                     --noplugins && \
-    microdnf install -y logrotate && \
+    microdnf install -y logrotate-3.14.0 && \
     microdnf clean all
 
 # https://mariadb.com/kb/en/rotating-logs-on-unix-and-linux


### PR DESCRIPTION
Also includes `logrotate` configurations for automatically creating daily archives. In terms of log retention, it mirrors the back-end, retaining logs within the last half of the year.