### PR TITLE
Updates to NGINX configuration

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -119,7 +119,9 @@ services:
     image: seart/ghs-website:preview
     container_name: gse-website
     volumes:
-      - ./nginx/default.dev.conf:/etc/nginx/conf.d/default.conf
+      - ./nginx/default.conf.template:/etc/nginx/templates/default.conf.template
+    environment:
+      BASE_URL: http://localhost:48001
     ports: [ "7030:80" ]
     deploy:
       restart_policy:

--- a/docker-compose/nginx/default.conf.template
+++ b/docker-compose/nginx/default.conf.template
@@ -10,3 +10,9 @@ server {
     sub_filter "http://localhost:8080" "${BASE_URL}";
   }
 }
+
+server {
+  listen 8000;
+  server_name localhost;
+  stub_status on;
+}

--- a/docker-compose/nginx/default.conf.template
+++ b/docker-compose/nginx/default.conf.template
@@ -7,6 +7,6 @@ server {
     index index.html index.htm;
     sub_filter_once off;
     sub_filter_types application/javascript;
-    sub_filter "http://localhost:8080" "http://localhost:48001";
+    sub_filter "http://localhost:8080" "${BASE_URL}";
   }
 }

--- a/docker/website/Dockerfile
+++ b/docker/website/Dockerfile
@@ -17,6 +17,8 @@ COPY --from=build dist /usr/share/nginx/html
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]
 
+EXPOSE 80 8000
+
 HEALTHCHECK \
     --start-period=10s \
     --interval=60s \

--- a/docker/website/Dockerfile
+++ b/docker/website/Dockerfile
@@ -14,7 +14,8 @@ ENV TZ=UTC
 
 COPY --from=build dist /usr/share/nginx/html
 
-ENTRYPOINT ["nginx", "-g", "daemon off;"]
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["nginx", "-g", "daemon off;"]
 
 HEALTHCHECK \
     --start-period=10s \


### PR DESCRIPTION
This PR introduces two major changes to the NGINX config:

- The default configuration file is generated from a template using the default `envsubst` templating behaviour supported by NGINX. This will no doubt make configuration easier when transitioning from a development environment into production;
- The re-introduction of an internal `stub_status` server. Although previously part of the exposed server block, we now dedicate an internal server block exposed on port `8000`. Although other services on the same network can access this endpoint, it will not be reachable to anyone outside the network