### PR TITLE
Improve `Statistics` modal

### DIFF
--- a/html/css/main.css
+++ b/html/css/main.css
@@ -91,6 +91,10 @@ input::-webkit-calendar-picker-indicator {
     cursor: not-allowed!important;
 }
 
+.btn:focus {
+    box-shadow: var(--ghs-box-shadow)!important;
+}
+
 .btn-close {
     border-radius: 0!important;
 }

--- a/html/css/main.css
+++ b/html/css/main.css
@@ -256,6 +256,19 @@ input::-webkit-calendar-picker-indicator {
     border-collapse: separate!important;
 }
 
+.table-centered td:not(:first-child),
+.table-centered th:not(:first-child) {
+    text-align: center!important;
+}
+
+.table-header-divider th {
+    border-bottom:
+            var(--bs-border-width)
+            var(--bs-border-style)
+            var(--bs-border-color)
+    !important;
+}
+
 .text-current {
     color: currentcolor!important;
 }
@@ -276,10 +289,23 @@ input::-webkit-calendar-picker-indicator {
 .modal-content {
     border-radius: 0!important;
 }
+
+.nav-tabs {
+    --bs-nav-tabs-border-radius: 0!important;
+    --bs-nav-tabs-link-hover-border-color: transparent!important;
+}
+
 .nav-link:focus-visible {
     box-shadow: var(--ghs-box-shadow)!important;
 }
 
+.nav-tabs .nav-link:not(.active) {
+    color: rgba(var(--bs-emphasis-color-rgb), 0.65)!important;
+}
+
+.nav-tabs .nav-link:hover:not(.active) {
+    color: rgba(var(--bs-emphasis-color-rgb), 0.8)!important;
+}
 
 div[data-ghs-id] {
     background-color: var(--bs-gray-200)!important;

--- a/html/css/main.css
+++ b/html/css/main.css
@@ -250,6 +250,12 @@ input::-webkit-calendar-picker-indicator {
     height: var(--ghs-spinner-size)!important;
 }
 
+.table {
+    margin: 0!important;
+    border-spacing: 0!important;
+    border-collapse: separate!important;
+}
+
 .text-current {
     color: currentcolor!important;
 }

--- a/html/css/main.css
+++ b/html/css/main.css
@@ -266,6 +266,10 @@ input::-webkit-calendar-picker-indicator {
 .modal-content {
     border-radius: 0!important;
 }
+.nav-link:focus-visible {
+    box-shadow: var(--ghs-box-shadow)!important;
+}
+
 
 div[data-ghs-id] {
     background-color: var(--bs-gray-200)!important;

--- a/html/css/main.css
+++ b/html/css/main.css
@@ -91,6 +91,14 @@ input::-webkit-calendar-picker-indicator {
     cursor: not-allowed!important;
 }
 
+.btn-close {
+    border-radius: 0!important;
+}
+
+.btn-close:focus {
+    box-shadow: var(--ghs-box-shadow)!important;
+}
+
 .btn-collapse[aria-expanded="false"]::before {
     content: "Show More";
 }

--- a/html/css/main.css
+++ b/html/css/main.css
@@ -43,6 +43,10 @@ a[target="_blank"] {
     cursor: alias!important;
 }
 
+canvas {
+    cursor: crosshair!important;
+}
+
 input[type="text"],
 input[type="number"],
 input[type="date"]

--- a/html/css/main.css
+++ b/html/css/main.css
@@ -256,17 +256,17 @@ input::-webkit-calendar-picker-indicator {
     border-collapse: separate!important;
 }
 
-.table-centered td:not(:first-child),
-.table-centered th:not(:first-child) {
-    text-align: center!important;
-}
-
 .table-header-divider th {
     border-bottom:
             var(--bs-border-width)
             var(--bs-border-style)
             var(--bs-border-color)
     !important;
+}
+
+.table-centered td:not(:first-child),
+.table-centered th:not(:first-child) {
+    text-align: center!important;
 }
 
 .text-current {

--- a/html/index.html
+++ b/html/index.html
@@ -945,18 +945,90 @@
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
           </div>
           <div class="modal-body">
-            <div class="position-relative mb-3">
-              <div class="position-absolute z-1 m-4 top-0 end-0">
-                <div class="btn-group">
-                  <button type="button" id="statistics-png-btn" class="btn btn-light d-none" disabled>
-                    <i class="bi bi-image-fill"></i>
-                  </button>
-                  <button type="button" id="statistics-csv-btn" class="btn btn-light d-none" disabled>
-                    <i class="bi bi-download"></i>
-                  </button>
+            <ul id="statistics-tab" role="tablist" class="nav nav-tabs">
+              <li role="presentation" class="nav-item">
+                <button id="statistics-chart-tab"
+                        role="tab"
+                        type="button"
+                        class="nav-link active"
+                        data-bs-toggle="tab"
+                        data-bs-target="#statistics-chart-pane"
+                        aria-controls="statistics-chart-pane"
+                        aria-selected="true"
+                >
+                  Chart
+                </button>
+              </li>
+              <li role="presentation" class="nav-item">
+                <button id="statistics-table-tab"
+                        role="tab"
+                        type="button"
+                        class="nav-link"
+                        data-bs-toggle="tab"
+                        data-bs-target="#statistics-table-pane"
+                        aria-controls="statistics-table-pane"
+                        aria-selected="false"
+                >
+                  Table
+                </button>
+              </li>
+              <li role="presentation" class="nav-item ms-auto">
+                <button id="statistics-csv-btn"
+                        type="button"
+                        class="btn rounded-0 d-none"
+                        aria-label="Download CSV"
+                        disabled
+                >
+                  <i class="bi bi-file-earmark-spreadsheet-fill"></i>
+                </button>
+              </li>
+              <li role="presentation" class="nav-item">
+                <button id="statistics-png-btn"
+                        type="button"
+                        class="btn rounded-0 d-none"
+                        aria-label="Download PNG"
+                        disabled
+                >
+                  <i class="bi bi-file-earmark-image-fill"></i>
+                </button>
+              </li>
+            </ul>
+            <div id="statistics-panes"
+                 class="tab-content border border-top-0 mb-3 overflow-y-auto"
+                 style="max-height: 401px!important;"
+            >
+              <div id="statistics-chart-pane"
+                   class="tab-pane fade show active"
+                   role="tabpanel"
+                   aria-labelledby="statistics-chart-tab"
+              >
+                <canvas id="statistics-chart" class="chart position-relative"></canvas>
+                <div role="alert" class="alert alert-warning d-md-none rounded-0 mx-3">
+                  The chart may not display optimally on mobile devices.
+                  For an enhanced viewing experience, please use a device with a larger screen.
                 </div>
               </div>
-              <canvas id="statistics-chart" class="chart position-relative"></canvas>
+              <div id="statistics-table-pane"
+                   class="tab-pane fade"
+                   role="tabpanel"
+                   aria-labelledby="statistics-table-tab"
+              >
+                <table id="statistics-table"
+                       class="table table-striped table-borderless table-centered"
+                       aria-label="Language Statistics"
+                >
+                  <thead class="sticky-top table-header-divider">
+                    <tr>
+                      <th scope="col">Language</th>
+                      <th scope="col">Mined</th>
+                      <th scope="col">Analyzed</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <!-- TABLE CONTENTS WILL BE INJECTED HERE -->
+                  </tbody>
+                </table>
+              </div>
             </div>
             <div class="d-flex justify-content-between justify-content-md-around text-center mb-3">
               <h2 class="fs-6 mb-0 placeholder-glow">
@@ -1125,6 +1197,15 @@
           <button type="button" data-bs-dismiss="toast" class="btn-close me-2 m-auto" aria-label="Close"></button>
         </div>
       </div>
+    </script>
+    <script id="template-table-rows" type="text/x-handlebars-template">
+      {{#each this}}
+      <tr>
+        <td>{{ language }}</td>
+        <td>{{localized mined}}</td>
+        <td>{{localized analyzed}}</td>
+      </tr>
+      {{/each}}
     </script>
     <script id="template-results-repo" type="text/x-handlebars-template">
       <div data-ghs-id="{{id}}" class="row border border-secondary border-top-0 border-start-0 border-end-0 mx-2 mb-3">

--- a/html/index.html
+++ b/html/index.html
@@ -1002,7 +1002,12 @@
                    role="tabpanel"
                    aria-labelledby="statistics-chart-tab"
               >
-                <canvas id="statistics-chart" class="chart position-relative"></canvas>
+                <canvas id="statistics-chart" class="chart position-relative d-none"></canvas>
+                <div id="statistics-chart-spinner" class="d-flex justify-content-center">
+                  <div class="spinner-border spinner-lg text-secondary m-5" role="status">
+                    <span class="visually-hidden">Loading...</span>
+                  </div>
+                </div>
                 <div role="alert" class="alert alert-warning d-md-none rounded-0 mx-3">
                   The chart may not display optimally on mobile devices.
                   For an enhanced viewing experience, please use a device with a larger screen.

--- a/html/index.html
+++ b/html/index.html
@@ -995,7 +995,7 @@
             </ul>
             <div id="statistics-panes"
                  class="tab-content border border-top-0 mb-3 overflow-y-auto"
-                 style="max-height: 401px!important;"
+                 style="max-height: 402px!important;"
             >
               <div id="statistics-chart-pane"
                    class="tab-pane fade show active"
@@ -1025,7 +1025,13 @@
                     </tr>
                   </thead>
                   <tbody>
-                    <!-- TABLE CONTENTS WILL BE INJECTED HERE -->
+                    <tr>
+                      <th scope="row" colspan="3" class="text-center">
+                        <div class="spinner-border spinner-lg text-secondary m-5" role="status">
+                          <span class="visually-hidden">Loading...</span>
+                        </div>
+                      </th>
+                    </tr>
                   </tbody>
                 </table>
               </div>

--- a/html/index.html
+++ b/html/index.html
@@ -946,10 +946,15 @@
           </div>
           <div class="modal-body">
             <div class="position-relative mb-3">
-              <div class="position-absolute z-1 top-0 end-0">
-                <button type="button" id="statistics-download-btn" class="btn btn-light m-4 d-none" disabled>
-                  <i class="bi bi-download"></i>
-                </button>
+              <div class="position-absolute z-1 m-4 top-0 end-0">
+                <div class="btn-group">
+                  <button type="button" id="statistics-png-btn" class="btn btn-light d-none" disabled>
+                    <i class="bi bi-image-fill"></i>
+                  </button>
+                  <button type="button" id="statistics-csv-btn" class="btn btn-light d-none" disabled>
+                    <i class="bi bi-download"></i>
+                  </button>
+                </div>
               </div>
               <canvas id="statistics-chart" class="chart position-relative"></canvas>
             </div>

--- a/html/js/chart.js
+++ b/html/js/chart.js
@@ -84,7 +84,9 @@
             const coverage = `${percentage(total.analyzed, total.mined)}%`;
             $statistics_mined.replaceWith(`<span id="statistics-mined">${total.mined.toLocaleString()}</span>`);
             $statistics_analyzed.replaceWith(`<span id="statistics-analyzed">${coverage}</span>`);
-            return Object.entries(json).map(([key, value]) => ({ x: key, ...value }));
+            return Object.entries(json)
+                .map(([key, value]) => ({ x: key, ...value }))
+                .filter(({ mined }) => mined > 0);
         })
         .then(data => {
             $statistics_download_btn.removeClass("d-none")

--- a/html/js/chart.js
+++ b/html/js/chart.js
@@ -20,7 +20,10 @@
         responsive: true,
         layout: {
             padding: {
-                right: 10,
+                top: 20,
+                left: 10,
+                bottom: 10,
+                right: 20,
             },
         },
         scales: {

--- a/html/js/chart.js
+++ b/html/js/chart.js
@@ -1,5 +1,6 @@
 (function (base, $, _, Handlebars, Chart, chroma) {
-    const [ canvas ] = $("#statistics-chart").get();
+    const $statistics_chart = $("#statistics-chart");
+    const $statistics_chart_spinner = $("#statistics-chart-spinner");
     const $toast_container = $(".toast-container");
     const $statistics_mined = $("#statistics-mined");
     const $statistics_analyzed = $("#statistics-analyzed");
@@ -8,6 +9,7 @@
     const $table_body = $("#statistics-table > tbody");
     const $table_rows_template = $("#template-table-rows").html();
     const $table_rows_content = Handlebars.compile($table_rows_template);
+    const [ canvas ] = $statistics_chart.get();
 
     const percentage = (numerator, denominator) => (numerator / denominator * 100).toFixed(2);
 
@@ -137,7 +139,11 @@
                 ]
             };
         })
-        .then(data => new Chart(canvas, { type: "bar", options, data }))
+        .then(data => {
+            $statistics_chart_spinner.addClass("d-none");
+            $statistics_chart.removeClass("d-none");
+            return new Chart(canvas, { type: "bar", options, data });
+        })
         .then(chart => {
             $statistics_png_btn.removeClass("d-none")
                 .prop("disabled", false)

--- a/html/js/chart.js
+++ b/html/js/chart.js
@@ -1,10 +1,13 @@
-(function (base, $, _, Chart, chroma) {
+(function (base, $, _, Handlebars, Chart, chroma) {
     const [ canvas ] = $("#statistics-chart").get();
     const $toast_container = $(".toast-container");
     const $statistics_mined = $("#statistics-mined");
     const $statistics_analyzed = $("#statistics-analyzed");
     const $statistics_csv_btn = $("#statistics-csv-btn");
     const $statistics_png_btn = $("#statistics-png-btn");
+    const $table_body = $("#statistics-table > tbody");
+    const $table_rows_template = $("#template-table-rows").html();
+    const $table_rows_content = Handlebars.compile($table_rows_template);
 
     const percentage = (numerator, denominator) => (numerator / denominator * 100).toFixed(2);
 
@@ -90,6 +93,11 @@
                 .filter(({ mined }) => mined > 0);
         })
         .then(data => {
+            const transformed = data.map(({x: language, mined, analyzed}) => ({language, mined, analyzed}));
+            $table_body.html($table_rows_content(transformed));
+            return data;
+        })
+        .then(data => {
             $statistics_csv_btn.removeClass("d-none")
                 .prop("disabled", false)
                 .on("click", () => {
@@ -143,4 +151,4 @@
             id: "statistics-toast",
             body: "Could not retrieve repository statistics!"
         }));
-}(base, jQuery, _, Chart, chroma));
+}(base, jQuery, _, Handlebars, Chart, chroma));

--- a/html/js/chart.js
+++ b/html/js/chart.js
@@ -3,7 +3,8 @@
     const $toast_container = $(".toast-container");
     const $statistics_mined = $("#statistics-mined");
     const $statistics_analyzed = $("#statistics-analyzed");
-    const $statistics_download_btn = $("#statistics-download-btn");
+    const $statistics_csv_btn = $("#statistics-csv-btn");
+    const $statistics_png_btn = $("#statistics-png-btn");
 
     const percentage = (numerator, denominator) => (numerator / denominator * 100).toFixed(2);
 
@@ -89,7 +90,7 @@
                 .filter(({ mined }) => mined > 0);
         })
         .then(data => {
-            $statistics_download_btn.removeClass("d-none")
+            $statistics_csv_btn.removeClass("d-none")
                 .prop("disabled", false)
                 .on("click", () => {
                     const header = "\"language\",\"mined\",\"analyzed\",\"coverage\"";
@@ -126,6 +127,18 @@
             };
         })
         .then(data => new Chart(canvas, { type: "bar", options, data }))
+        .then(chart => {
+            $statistics_png_btn.removeClass("d-none")
+                .prop("disabled", false)
+                .on("click", () => {
+                    const url = chart.toBase64Image();
+                    const anchor = document.createElement("a");
+                    anchor.setAttribute("href", url);
+                    anchor.setAttribute("download", "statistics.png");
+                    anchor.click();
+                    anchor.remove();
+                });
+        })
         .catch(() => $toast_container.twbsToast({
             id: "statistics-toast",
             body: "Could not retrieve repository statistics!"


### PR DESCRIPTION
The present state of the modal has made it difficult to read on small devices. This PR adds a table to the statistics presentation, which is easier to read on smaller screens. Includes a plethora of quality-of-life improvements, such as separate panes for each visualisation, multiple export options and loading states.