### PR TITLE
Revert "Bump mysql from 8.3.0 to 8.4.0 in /docker/database"

### DIFF
--- a/docker/database/Dockerfile
+++ b/docker/database/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:8.4.0
+FROM mysql:8.3.0
 LABEL maintainer="Ozren Dabić (dabico@usi.ch)"
 
 WORKDIR /docker-entrypoint-initdb.d


### PR DESCRIPTION
Seems like the image does not work when trying to create an instance from scratch:

```
2024-05-29T09:09:54.311283343Z 2024-05-29 09:09:54+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.4.0-1.el9 started.
2024-05-29T09:09:54.708991811Z 2024-05-29 09:09:54+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
2024-05-29T09:09:54.724916611Z 2024-05-29 09:09:54+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.4.0-1.el9 started.
2024-05-29T09:09:54.949993410Z 2024-05-29 09:09:54+00:00 [Note] [Entrypoint]: Initializing database files
2024-05-29T09:09:54.968515283Z 2024-05-29T09:09:54.964175Z 0 [System] [MY-015017] [Server] MySQL Server Initialization - start.
2024-05-29T09:09:54.968532626Z 2024-05-29T09:09:54.966062Z 0 [System] [MY-013169] [Server] /usr/sbin/mysqld (mysqld 8.4.0) initializing of server in progress as process 80
2024-05-29T09:09:54.976780399Z 2024-05-29T09:09:54.976475Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.
2024-05-29T09:09:55.260322384Z 2024-05-29T09:09:55.260092Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.
2024-05-29T09:09:56.910676461Z 2024-05-29T09:09:56.910374Z 6 [Warning] [MY-010453] [Server] root@localhost is created with an empty password ! Please consider switching off the --initialize-insecure option.
2024-05-29T09:09:58.978923584Z 2024-05-29T09:09:58.978608Z 0 [System] [MY-015018] [Server] MySQL Server Initialization - end.
2024-05-29T09:09:59.000394771Z 2024-05-29 09:09:58+00:00 [Note] [Entrypoint]: Database files initialized
2024-05-29T09:09:59.002972808Z 2024-05-29 09:09:59+00:00 [Note] [Entrypoint]: Starting temporary server
2024-05-29T09:09:59.268425814Z 2024-05-29T09:09:59.020958Z 0 [System] [MY-015015] [Server] MySQL Server - start.
2024-05-29T09:09:59.268458052Z 2024-05-29T09:09:59.259120Z 0 [System] [MY-010116] [Server] /usr/sbin/mysqld (mysqld 8.4.0) starting as process 123
2024-05-29T09:09:59.277928871Z 2024-05-29T09:09:59.277644Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.
2024-05-29T09:09:59.491754877Z 2024-05-29T09:09:59.491537Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.
2024-05-29T09:09:59.743212550Z 2024-05-29T09:09:59.742929Z 0 [Warning] [MY-010068] [Server] CA certificate ca.pem is self signed.
2024-05-29T09:09:59.743230255Z 2024-05-29T09:09:59.742988Z 0 [System] [MY-013602] [Server] Channel mysql_main configured to support TLS. Encrypted connections are now supported for this channel.
2024-05-29T09:09:59.748660749Z 2024-05-29T09:09:59.748397Z 0 [Warning] [MY-011810] [Server] Insecure configuration for --pid-file: Location '/var/run/mysqld' in the path is accessible to all OS users. Consider choosing a different directory.
2024-05-29T09:09:59.770771878Z 2024-05-29T09:09:59.770542Z 0 [System] [MY-010931] [Server] /usr/sbin/mysqld: ready for connections. Version: '8.4.0'  socket: '/var/run/mysqld/mysqld.sock'  port: 0  MySQL Community Server - GPL.
2024-05-29T09:09:59.782288850Z 2024-05-29 09:09:59+00:00 [Note] [Entrypoint]: Temporary server started.
2024-05-29T09:09:59.812503858Z '/var/lib/mysql/mysql.sock' -> '/var/run/mysqld/mysqld.sock'
2024-05-29T09:10:00.025941263Z 2024-05-29T09:10:00.025610Z 0 [System] [MY-011323] [Server] X Plugin ready for connections. Socket: /var/run/mysqld/mysqlx.sock
2024-05-29T09:10:00.645958031Z Warning: Unable to load '/usr/share/zoneinfo/iso3166.tab' as time zone. Skipping it.
2024-05-29T09:10:00.645974241Z Warning: Unable to load '/usr/share/zoneinfo/leap-seconds.list' as time zone. Skipping it.
2024-05-29T09:10:00.645976558Z Warning: Unable to load '/usr/share/zoneinfo/leapseconds' as time zone. Skipping it.
2024-05-29T09:10:02.393492911Z Warning: Unable to load '/usr/share/zoneinfo/tzdata.zi' as time zone. Skipping it.
2024-05-29T09:10:02.393508803Z Warning: Unable to load '/usr/share/zoneinfo/zone.tab' as time zone. Skipping it.
2024-05-29T09:10:02.393511360Z Warning: Unable to load '/usr/share/zoneinfo/zone1970.tab' as time zone. Skipping it.
2024-05-29T09:10:02.531871479Z 2024-05-29 09:10:02+00:00 [Note] [Entrypoint]: Creating database gse
2024-05-29T09:10:02.543765907Z 2024-05-29 09:10:02+00:00 [Note] [Entrypoint]: Creating user gseadmin
2024-05-29T09:10:02.559984029Z 2024-05-29 09:10:02+00:00 [Note] [Entrypoint]: Giving user gseadmin access to schema gse
2024-05-29T09:10:02.569579576Z 
2024-05-29T09:10:02.571371807Z 2024-05-29 09:10:02+00:00 [Note] [Entrypoint]: /usr/local/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/gse.sql.gz
2024-05-29T09:10:27.816215288Z 2024-05-29T09:10:27.815876Z 0 [Warning] [MY-015116] [Server] Background histogram update on gse.git_repo: Lock wait timeout exceeded; try restarting transaction
2024-05-29T09:10:42.847163282Z 2024-05-29T09:10:42.846934Z 0 [Warning] [MY-015116] [Server] Background histogram update on gse.git_repo: Lock wait timeout exceeded; try restarting transaction
2024-05-29T09:10:42.847182325Z 2024-05-29T09:10:42.846978Z 0 [Warning] [MY-015116] [Server] Background histogram update on gse.git_repo: Lock wait timeout exceeded; try restarting transaction
2024-05-29T09:10:57.903345704Z 2024-05-29T09:10:57.903079Z 0 [Warning] [MY-015116] [Server] Background histogram update on gse.git_repo: Lock wait timeout exceeded; try restarting transaction
2024-05-29T09:10:57.903365162Z 2024-05-29T09:10:57.903125Z 0 [Warning] [MY-015116] [Server] Background histogram update on gse.git_repo: Lock wait timeout exceeded; try restarting transaction
2024-05-29T09:10:57.903368220Z 2024-05-29T09:10:57.903131Z 0 [Warning] [MY-015116] [Server] Background histogram update on gse.git_repo: Lock wait timeout exceeded; try restarting transaction
2024-05-29T09:11:17.813362158Z 2024-05-29T09:11:17.813077Z 0 [Warning] [MY-015116] [Server] Background histogram update on gse.git_repo: Lock wait timeout exceeded; try restarting transaction
2024-05-29T09:11:17.813383025Z 2024-05-29T09:11:17.813136Z 0 [Warning] [MY-015116] [Server] Background histogram update on gse.git_repo: Lock wait timeout exceeded; try restarting transaction
2024-05-29T09:11:17.813386404Z 2024-05-29T09:11:17.813143Z 0 [Warning] [MY-015116] [Server] Background histogram update on gse.git_repo: Lock wait timeout exceeded; try restarting transaction
2024-05-29T09:11:17.813388932Z 2024-05-29T09:11:17.813148Z 0 [Warning] [MY-015116] [Server] Background histogram update on gse.git_repo: Lock wait timeout exceeded; try restarting transaction
2024-05-29T09:11:30.169436036Z 2024-05-29T09:11:30.169029Z 0 [Warning] [MY-015116] [Server] Background histogram update on gse.git_repo: Lock wait timeout exceeded; try restarting transaction
2024-05-29T09:11:30.169494931Z 2024-05-29T09:11:30.169106Z 0 [Warning] [MY-015116] [Server] Background histogram update on gse.git_repo: Lock wait timeout exceeded; try restarting transaction
2024-05-29T09:11:30.169500348Z 2024-05-29T09:11:30.169119Z 0 [Warning] [MY-015116] [Server] Background histogram update on gse.git_repo: Lock wait timeout exceeded; try restarting transaction
2024-05-29T09:11:30.169502406Z 2024-05-29T09:11:30.169127Z 0 [Warning] [MY-015116] [Server] Background histogram update on gse.git_repo: Lock wait timeout exceeded; try restarting transaction
2024-05-29T09:11:30.169504171Z 2024-05-29T09:11:30.169133Z 0 [Warning] [MY-015116] [Server] Background histogram update on gse.git_repo: Lock wait timeout exceeded; try restarting transaction
2024-05-29T09:11:47.713272898Z 2024-05-29T09:11:47.713016Z 0 [Warning] [MY-015116] [Server] Background histogram update on gse.git_repo: Lock wait timeout exceeded; try restarting transaction
2024-05-29T09:11:47.713292142Z 2024-05-29T09:11:47.713065Z 0 [Warning] [MY-015116] [Server] Background histogram update on gse.git_repo: Lock wait timeout exceeded; try restarting transaction
2024-05-29T09:11:47.713295190Z 2024-05-29T09:11:47.713072Z 0 [Warning] [MY-015116] [Server] Background histogram update on gse.git_repo: Lock wait timeout exceeded; try restarting transaction
2024-05-29T09:11:47.713297354Z 2024-05-29T09:11:47.713098Z 0 [Warning] [MY-015116] [Server] Background histogram update on gse.git_repo: Lock wait timeout exceeded; try restarting transaction
2024-05-29T09:11:47.713299359Z 2024-05-29T09:11:47.713105Z 0 [Warning] [MY-015116] [Server] Background histogram update on gse.git_repo: Lock wait timeout exceeded; try restarting transaction
2024-05-29T09:11:47.713301346Z 2024-05-29T09:11:47.713108Z 0 [Warning] [MY-015116] [Server] Background histogram update on gse.git_repo: Lock wait timeout exceeded; try restarting transaction
2024-05-29T09:12:08.241188972Z 2024-05-29T09:12:08.240947Z 0 [Warning] [MY-015116] [Server] Background histogram update on gse.git_repo: Lock wait timeout exceeded; try restarting transaction
2024-05-29T09:12:08.241209426Z 2024-05-29T09:12:08.240992Z 0 [Warning] [MY-015116] [Server] Background histogram update on gse.git_repo: Lock wait timeout exceeded; try restarting transaction
2024-05-29T09:12:08.241212902Z 2024-05-29T09:12:08.240999Z 0 [Warning] [MY-015116] [Server] Background histogram update on gse.git_repo: Lock wait timeout exceeded; try restarting transaction
2024-05-29T09:12:08.241215198Z 2024-05-29T09:12:08.241003Z 0 [Warning] [MY-015116] [Server] Background histogram update on gse.git_repo: Lock wait timeout exceeded; try restarting transaction
2024-05-29T09:12:08.241217299Z 2024-05-29T09:12:08.241007Z 0 [Warning] [MY-015116] [Server] Background histogram update on gse.git_repo: Lock wait timeout exceeded; try restarting transaction
2024-05-29T09:12:08.241219376Z 2024-05-29T09:12:08.241010Z 0 [Warning] [MY-015116] [Server] Background histogram update on gse.git_repo: Lock wait timeout exceeded; try restarting transaction
2024-05-29T09:12:08.241221438Z 2024-05-29T09:12:08.241014Z 0 [Warning] [MY-015116] [Server] Background histogram update on gse.git_repo: Lock wait timeout exceeded; try restarting transaction
```

Attempting to start the container in 8.3 does not yield these warnings. Furthermore, I have a strong reason to suspect that this version upgrade is also behind the recent performance degradations we are experiencing in production. For instance, a simple `EXPLAIN` that locally yields the following result:

```
mysql> explain analyze
    -> select distinct
    -> gitrepo0_.id as id1_0_,
    -> gitrepo0_.branches as branches2_0_,
    -> gitrepo0_.commits as commits3_0_,
    -> gitrepo0_.contributors as contribu4_0_,
    -> gitrepo0_.created_at as created_5_0_,
    -> gitrepo0_.default_branch as default_6_0_,
    -> gitrepo0_.forks as forks7_0_,
    -> gitrepo0_.has_wiki as has_wiki8_0_,
    -> gitrepo0_.homepage as homepage9_0_,
    -> gitrepo0_.archived as archive10_0_,
    -> gitrepo0_.disabled as disable11_0_,
    -> gitrepo0_.is_fork_project as is_fork12_0_,
    -> gitrepo0_.locked as locked13_0_,
    -> gitrepo0_.last_analyzed as last_an14_0_,
    -> gitrepo0_.last_commit as last_co15_0_,
    -> gitrepo0_.last_commit_sha as last_co16_0_,
    -> gitrepo0_.last_pinged as last_pi17_0_,
    -> gitrepo0_.license_id as license29_0_,
    -> gitrepo0_.language_id as languag30_0_,
    -> gitrepo0_.name as name18_0_,
    -> gitrepo0_.open_issues as open_is19_0_,
    -> gitrepo0_.open_pull_requests as open_pu20_0_,
    -> gitrepo0_.pushed_at as pushed_21_0_,
    -> gitrepo0_.releases as release22_0_,
    -> gitrepo0_.size as size23_0_,
    -> gitrepo0_.stargazers as stargaz24_0_,
    -> gitrepo0_.total_issues as total_i25_0_,
    -> gitrepo0_.total_pull_requests as total_p26_0_,
    -> gitrepo0_.updated_at as updated27_0_,
    -> gitrepo0_.watchers as watcher28_0_
    -> from git_repo gitrepo0_
    -> where gitrepo0_.created_at
    -> between '2024-01-01' and '2024-01-01'
    -> order by gitrepo0_. name asc limit 20;

+-------------------------------------------------------------------------------------------------------------------------------------+
| EXPLAIN                                                                                                                             |
+-------------------------------------------------------------------------------------------------------------------------------------+
| -> Limit: 20 row(s)  (cost=2.12 rows=2) (actual time=17934..17934 rows=0 loops=1)                                                   |
|    -> Filter: (gitrepo0_.created_at = TIMESTAMP'2024-01-01 00:00:00')  (cost=2.12 rows=2) (actual time=17934..17934 rows=0 loops=1) |
|        -> Index scan on gitrepo0_ using unique_repo_name  (cost=2.12 rows=20) (actual time=0.331..17753 rows=1.55e+6 loops=1)       |
+-------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (17.93 sec)
```

Never seems to finish in our production database.

In short, this PR reverts seart-group/ghs#364. Given our past problems with upgrading `flyway`, I think it's best not to rely on automatic upgrades for docker images (especially MySQL).